### PR TITLE
docs: add boundary matrix, ADR, org modularization index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Documentation for org modularization program:
+  - `docs/org-modularization.md` (standards, workstream index for #35–#43, git/build/beads rules, audit commands)
+  - `docs/adr/001-traits-in-neuromod.md` (records decision to host shared traits in neuromod)
+  - `docs/neuromod-boundary-matrix.md` (runtime/deployment boundary matrix per LIM-9 / #11 / #25)
+
 ### Changed
 
 - **License:** switched from GPL-3.0 to dual MIT/Apache-2.0 for maximum adoption and ecosystem health.
+- README now links the new Architecture & Boundaries docs.
 
 ## [0.5.0] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   docker build --target builder -t neuromod:builder .
   docker run --rm neuromod:builder cargo test --all-features --quiet
   ```
-- **Azure Pipelines** (`azure-pipelines.yml`): Cross-platform (Linux / Windows / macOS) parity. For branch protection, require the three per-OS checks (`Limen-Neural.neuromod (BuildTest linux)`, `Limen-Neural.neuromod (BuildTest mac)`, `Limen-Neural.neuromod (BuildTest windows)`), not the parent aggregate `Limen-Neural.neuromod`.
+- **Azure Pipelines** (`azure-pipelines.yml`): Cross-platform (Linux / Windows / macOS) parity using three explicit jobs (one check per OS). 
+  - Pure docs / markdown / non-code PRs are skipped via path filtering (no Azure checks at all).
+  - For branch protection on `main`, **require only the three per-OS checks**:
+    - `Limen-Neural.neuromod (BuildTest linux)`
+    - `Limen-Neural.neuromod (BuildTest mac)`
+    - `Limen-Neural.neuromod (BuildTest windows)`
+  - **Do not require** the parent aggregate `Limen-Neural.neuromod` (it is redundant and always appears alongside the jobs).
 
 ### Error monitoring (optional `sentry` feature)
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ For legacy hardware-calibrated signal mapping, use `SignalProfile::hardware_cali
   - `apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`
   - `EligibilityTrace`, `RmStdpConfig`
 
+## Architecture & Boundaries
+
+`neuromod` is the core library layer for neuron dynamics, generic neuromodulation, and foundational plasticity primitives.
+
+See the full planning documents:
+
+- [Org Modularization Standards](docs/org-modularization.md) — workstream index (#35–#43), cross-cutting git/build/beads standards, and audit commands.
+- [neuromod Boundary Matrix](docs/neuromod-boundary-matrix.md) — runtime/deployment role, owns/does-not-own, allowed/forbidden dependencies vs. limbic-critic, brainstem-daemon, axon-encoder, synaptic-mesh, silicon-bridge, Spikenaut-Hardware, plasticity-lab, etc. (LIM-9).
+- [ADR 001: Shared traits live in neuromod](docs/adr/001-traits-in-neuromod.md) — why traits are hosted here.
+
 ## Examples
 
 Run included examples:

--- a/README.md
+++ b/README.md
@@ -208,13 +208,7 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   docker build --target builder -t neuromod:builder .
   docker run --rm neuromod:builder cargo test --all-features --quiet
   ```
-- **Azure Pipelines** (`azure-pipelines.yml`): Cross-platform (Linux / Windows / macOS) parity using three explicit jobs (one check per OS). 
-  - Pure docs / markdown / non-code PRs are skipped via path filtering (no Azure checks at all).
-  - For branch protection on `main`, **require only the three per-OS checks**:
-    - `Limen-Neural.neuromod (BuildTest linux)`
-    - `Limen-Neural.neuromod (BuildTest mac)`
-    - `Limen-Neural.neuromod (BuildTest windows)`
-  - **Do not require** the parent aggregate `Limen-Neural.neuromod` (it is redundant and always appears alongside the jobs).
+- **Azure Pipelines** (`azure-pipelines.yml`): Cross-platform (Linux / Windows / macOS) parity. Three explicit jobs so GitHub surfaces one check per OS. For branch protection, require the three per-OS checks (`Limen-Neural.neuromod (BuildTest linux)`, `Limen-Neural.neuromod (BuildTest mac)`, `Limen-Neural.neuromod (BuildTest windows)`), not the parent aggregate `Limen-Neural.neuromod`. The parent aggregate check will still appear.
 
 ### Error monitoring (optional `sentry` feature)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,7 @@
 # Azure Pipelines for cross-platform parity (Linux / Windows / macOS)
 # Pipeline: Limen-Neural.neuromod (id=1) in the "CI CD" project at https://dev.azure.com/Limen-Neural
 # Modeled on metabolic-ledger/full-ci (id=5) and the planned brainstem-daemon Azure setup (GH#21).
-#
-# Three explicit jobs (not matrix) so GitHub gets one check per OS.
-# IMPORTANT: In GitHub branch protection, require ONLY the three per-OS checks:
-#   Limen-Neural.neuromod (BuildTest linux)
-#   Limen-Neural.neuromod (BuildTest mac)
-#   Limen-Neural.neuromod (BuildTest windows)
-# Do NOT require the parent aggregate "Limen-Neural.neuromod" (it is redundant).
-#
-# Path filtering below skips Azure entirely for pure-docs / non-code PRs to avoid noise.
+# Three explicit jobs (not matrix) so GitHub gets one check per OS; require the per-OS legs in branch protection.
 trigger:
   branches:
     include:
@@ -18,18 +10,6 @@ pr:
   branches:
     include:
       - main
-  paths:
-    exclude:
-      # Pure documentation / non-code changes should not trigger full cross-OS Azure builds
-      - docs/**
-      - README.md
-      - CHANGELOG.md
-      - LICENSE*
-      - '*.md'
-      - .github/ISSUE_TEMPLATE/**
-      - .github/PULL_REQUEST_TEMPLATE*
-      - codecov.yml
-      - azure-pipelines.yml  # itself only if other changes; but keep simple
   autoCancel: false
 variables:
   CARGO_HOME: $(Pipeline.workspace)/.cargo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,15 @@
 # Azure Pipelines for cross-platform parity (Linux / Windows / macOS)
 # Pipeline: Limen-Neural.neuromod (id=1) in the "CI CD" project at https://dev.azure.com/Limen-Neural
 # Modeled on metabolic-ledger/full-ci (id=5) and the planned brainstem-daemon Azure setup (GH#21).
-# Three explicit jobs (not matrix) so GitHub gets one check per OS; require the per-OS legs in branch protection.
+#
+# Three explicit jobs (not matrix) so GitHub gets one check per OS.
+# IMPORTANT: In GitHub branch protection, require ONLY the three per-OS checks:
+#   Limen-Neural.neuromod (BuildTest linux)
+#   Limen-Neural.neuromod (BuildTest mac)
+#   Limen-Neural.neuromod (BuildTest windows)
+# Do NOT require the parent aggregate "Limen-Neural.neuromod" (it is redundant).
+#
+# Path filtering below skips Azure entirely for pure-docs / non-code PRs to avoid noise.
 trigger:
   branches:
     include:
@@ -10,6 +18,18 @@ pr:
   branches:
     include:
       - main
+  paths:
+    exclude:
+      # Pure documentation / non-code changes should not trigger full cross-OS Azure builds
+      - docs/**
+      - README.md
+      - CHANGELOG.md
+      - LICENSE*
+      - '*.md'
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE*
+      - codecov.yml
+      - azure-pipelines.yml  # itself only if other changes; but keep simple
   autoCancel: false
 variables:
   CARGO_HOME: $(Pipeline.workspace)/.cargo

--- a/docs/adr/001-traits-in-neuromod.md
+++ b/docs/adr/001-traits-in-neuromod.md
@@ -1,0 +1,58 @@
+# ADR 001: Shared traits live in neuromod
+
+**Status:** Accepted (after #37 merges)
+
+**Date:** 2026-07-04
+
+## Context
+
+The Limen-Neural org maintains a growing collection of Rust crates for spiking neural networks and related neuromorphic infrastructure (encoding, topology, runtime, deployment, training, hardware). Multiple crates need common interfaces (e.g. for neurons, networks, modulators, reward) so that:
+
+- Downstream code (plasticity-lab, brainstem-daemon, hybrid-fusion, thalamic-relay, etc.) can depend on contracts without pulling in concrete implementations or creating tight coupling.
+- Changes to shared interfaces are governed by a single semver surface.
+- Duplication and drift are avoided.
+
+A separate `limen-traits` crate was considered but would add repo overhead, publishing complexity, and another moving part for a small number of focused contracts. Per-repo copies risk divergence.
+
+After the trait audit (#35) and design (#36), the decision point is where the canonical definitions should live.
+
+## Decision
+
+Shared traits (and closely related core types where the trait is the primary public surface) are defined and exported from the `neuromod` crate.
+
+No new dedicated traits-only repository will be created.
+
+`neuromod` already hosts the foundational dynamics (neuron models, `SpikingNetwork`, `NeuroModulators`, `GenericReward`). It is the natural home for the contracts that describe those dynamics.
+
+## Consequences
+
+- Sibling repos depend on `neuromod` (via git `branch = "main"` or published version) for the shared interfaces.
+- Semver rules apply to trait changes: breaking changes to a trait bump the major version of `neuromod`.
+- `neuromod` must remain focused (core library layer) — it does not absorb encoding, topology, reward shaping, or runtime concerns (see boundary matrix in `docs/neuromod-boundary-matrix.md`).
+- Concrete implementations in `neuromod` (e.g. `LifNeuron`, `SpikingNetwork`) will implement the traits; downstream crates can provide alternative implementations behind the same traits.
+- Documentation and examples must clearly separate "the trait" from "the neuromod-provided implementation".
+- The existing `GenericReward` trait serves as the precedent and proof-of-concept for this placement.
+
+## Alternatives Considered
+
+- **Separate `limen-traits` crate** — Rejected. Extra repository, separate release cadence, and maintenance burden for what is a thin set of contracts tightly related to neuromod's core models. Increases friction for the small team.
+- **Per-repo trait copies** — Rejected. High risk of drift (different method signatures, documentation, semantics) leading to integration bugs and duplicated maintenance.
+- **Move traits into `synaptic-mesh` or another peer** — Rejected. `neuromod` is the lowest layer for neuron/network dynamics; other crates are either peers (mesh, encoder) or consumers.
+
+## References
+
+- Parent epic: #44 (org modularization standards and index)
+- Depends on: #37 (implement and export core traits from neuromod)
+- Related: #35 (audit), #36 (design), #43 (this ADR)
+- `GenericReward` definition: `src/modulators.rs`
+- Cross-repo usage examples: plasticity-lab, hybrid-fusion, brainstem-daemon, limbic-critic boundary notes
+- Boundary matrix: `docs/neuromod-boundary-matrix.md`
+- Git dep standard (see `docs/org-modularization.md`)
+
+## Acceptance
+
+- [ ] Traits defined and exported per the #36 spec and #37 implementation
+- [ ] `cargo doc --no-deps` and tests pass
+- [ ] README and rustdoc updated
+- [ ] This file committed and linked from README
+- [ ] Sibling repos can consume the traits (follow-up work)

--- a/docs/neuromod-boundary-matrix.md
+++ b/docs/neuromod-boundary-matrix.md
@@ -38,7 +38,7 @@ It is a pure computation library: no I/O, no hardware, no application orchestrat
 
 - `serde` (with derive) — for serialization of core types
 - `rand` — for stochastic elements inside neuron models
-- `sentry` (optional, feature-gated) — error monitoring only
+- `sentry` (optional, feature-gated) — error monitoring only (intentional exception to the no-I/O rule)
 - Minimal std + the above; keep the crate lightweight and portable
 
 ## Forbidden Dependencies / Domains
@@ -54,8 +54,8 @@ It is a pure computation library: no I/O, no hardware, no application orchestrat
 
 | Layer                  | Responsibility                                      | Example Repos                          |
 |------------------------|-----------------------------------------------------|----------------------------------------|
-| **Core Library**       | Neuron dynamics, network step, generic modulators, plasticity primitives, shared traits | `neuromod`, `limbic-critic`            |
-| **Supervisor/App**     | Encoding, topology, training loops, IPC, runtime daemon | `axon-encoder`, `synaptic-mesh`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `thalamic-relay` |
+| **Core Library**       | Neuron dynamics, network step, generic modulators, plasticity primitives, foundational shared traits | `neuromod`            |
+| **Supervisor/App**     | Encoding, topology, training loops, IPC, runtime daemon, reward shaping | `axon-encoder`, `synaptic-mesh`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `thalamic-relay`, `limbic-critic` |
 | **Deployment/Hardware**| Parameter export, fixed-point, UART, HDL synthesis  | `silicon-bridge`, `Spikenaut-Hardware` |
 
 ## Domain Leaks

--- a/docs/neuromod-boundary-matrix.md
+++ b/docs/neuromod-boundary-matrix.md
@@ -1,0 +1,95 @@
+# neuromod: Runtime/Deployment Boundary Matrix
+
+> Part of the [LIM-9](https://linear.app/saaq-spiking-adaptive-activity/issue/LIM-9/plan-rust-runtime-and-deployment-repo-boundary-matrix) Rust runtime boundary planning work.
+> Tracked by: [neuromod #11](https://github.com/Limen-Neural/neuromod/issues/11), [neuromod #25](https://github.com/Limen-Neural/neuromod/issues/25)
+
+## Purpose
+
+`neuromod` is the **core reusable SNN library** providing biologically grounded neuron models, a topology-neutral dynamic `SpikingNetwork`, generic neuromodulation, and foundational plasticity primitives.
+
+It is a pure computation library: no I/O, no hardware, no application orchestration, and no domain-specific reward or topology logic. It is intended to be depended upon by supervisor runtimes, training loops, encoders, meshes, and export layers across the Limen-Neural org.
+
+## Owns
+
+- Neuron model implementations (Lapicque, LIF, GIF, Izhikevich, FitzHugh-Nagumo, Hodgkin-Huxley)
+- `SpikingNetwork` (including `new()`, `with_dimensions()`, `step()`, state accessors, `StepError`)
+- `NeuroModulators` (dopamine, serotonin, acetylcholine, norepinephrine), `SignalProfile` (default + hardware_calibrated), `Observation`, `GenericReward` trait, `UnitReward`, `apply_reward`, `apply_neuromodulation`
+- Foundational plasticity building blocks:
+  - Reward-modulated STDP (`rm_stdp`: `EligibilityTrace`, `RmStdpConfig`, constants)
+  - Classical Hebbian STDP (`hebbian`: `apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`)
+- Domain-agnostic contracts and errors for downstream integration
+
+## Does Not Own
+
+- Sensory / spike encoding algorithms or `Encoder` trait (owned by `axon-encoder`)
+- Topology generation, synaptic wiring, axonal delays, or mesh infrastructure (owned by `synaptic-mesh`)
+- Reward shaping, credit assignment, `Environment` trait, or modulator mapping from objectives (owned by `limbic-critic`)
+- Full training loops, orchestration, progress tracking, or checkpointing (owned by `plasticity-lab`)
+- IPC protocols, transports, backends, or messaging (owned by `corpus-ipc`)
+- Headless runtime execution, daemon loop, service registry, or TOML config (owned by `brainstem-daemon`)
+- FPGA parameter export, Q8.8 fixed-point conversion, UART bridge, or metrics (owned by `silicon-bridge`)
+- HDL / SystemVerilog implementations or hardware coordination (owned by `silicon-hdl` / `Spikenaut-Hardware`)
+- Tensor math, MoE extraction, hybrid ANN-SNN orchestration, or projectors (owned by `cortex-tensor`, `engram-parser`, `hybrid-fusion`)
+- Streaming feature extraction / stochastic signal stats (owned by `kinetic-signals`)
+- Energy / metabolic modeling or ledgers (owned by `metabolic-ledger`)
+- Supervision / relay (CPU+GPU) (owned by `thalamic-relay`)
+
+## Allowed Dependencies
+
+- `serde` (with derive) — for serialization of core types
+- `rand` — for stochastic elements inside neuron models
+- `sentry` (optional, feature-gated) — error monitoring only
+- Minimal std + the above; keep the crate lightweight and portable
+
+## Forbidden Dependencies / Domains
+
+- Any I/O, networking, async runtimes (tokio, zmq, etc.)
+- Hardware, FPGA, or fixed-point crates
+- Domain-specific reward or environment implementations
+- Training / optimization frameworks
+- Application / supervisor orchestration logic
+- Julia FFI or cross-language concerns (handled in consumer crates)
+
+## Core-Library vs Supervisor/App vs Deployment/Hardware Boundaries
+
+| Layer                  | Responsibility                                      | Example Repos                          |
+|------------------------|-----------------------------------------------------|----------------------------------------|
+| **Core Library**       | Neuron dynamics, network step, generic modulators, plasticity primitives, shared traits | `neuromod`, `limbic-critic`            |
+| **Supervisor/App**     | Encoding, topology, training loops, IPC, runtime daemon | `axon-encoder`, `synaptic-mesh`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `thalamic-relay` |
+| **Deployment/Hardware**| Parameter export, fixed-point, UART, HDL synthesis  | `silicon-bridge`, `Spikenaut-Hardware` |
+
+## Domain Leaks
+
+1. Historical naming (pre-0.5 "spikenaut", mining/HFT references) — cleaned in 0.5.0; docs and code are now domain-agnostic.
+2. `GenericReward` + `UnitReward` are intentionally minimal examples; real reward logic must live in `limbic-critic` or domain adapters.
+
+## Migration Risks
+
+| Risk                              | Severity | Mitigation |
+|-----------------------------------|----------|------------|
+| Downstream crates assuming concrete types instead of future traits | Medium | #37 + #43 (traits + ADR) |
+| Version skew on `neuromod` (some crates pin old 0.4 / revs) | Medium | #42 (remove rev pins), use `branch = "main"` going forward |
+| Accidental domain logic creeping into core models | Low | Strict review + CI domain-agnostic grep |
+
+## Sequencing Questions
+
+1. When #37 lands, should `SpikingNetwork` (and neuron types) become trait-based for easier substitution?
+2. Should basic `GenericReward` example stay in neuromod, or move example impls strictly to `limbic-critic`?
+3. How do topology-aware networks in `synaptic-mesh` compose with the flat `SpikingNetwork` here?
+
+## Related Boundary Issues
+
+- [neuromod #11](https://github.com/Limen-Neural/neuromod/issues/11)
+- [neuromod #25](https://github.com/Limen-Neural/neuromod/issues/25)
+- limbic-critic boundary matrix (docs/BOUNDARY_MATRIX.md)
+- [brainstem-daemon #4](https://github.com/Limen-Neural/brainstem-daemon/issues/4)
+- [silicon-bridge #3](https://github.com/Limen-Neural/silicon-bridge/issues/3)
+- [Spikenaut-Hardware #3](https://github.com/Limen-Neural/Spikenaut-Hardware/issues/3)
+- hybrid-fusion LIM-9 boundary notes
+- See also the org modularization index (#44) and ADR (#43)
+
+## Validation
+
+- This document is planning-only (no implementation changes).
+- Cross-checked against current source (`src/lib.rs`, `src/modulators.rs`, `src/engine.rs`, neuron modules) and sibling READMEs / boundary docs.
+- Output linkable from Linear LIM-9 and the listed GitHub issues.

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -55,7 +55,7 @@ Tooling: #39 (parallel)
   ```
 - Current examples of pinned usage (to be cleaned by #42 work) exist in plasticity-lab, etc.
 
-**Release profile template**
+### Release profile template
 
 Every active Rust crate should include:
 

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -68,7 +68,7 @@ codegen-units = 1
 
 (This is already present in `neuromod/Cargo.toml` and was validated under #40.)
 
-**Beads**
+### Beads
 
 - Every active org repo should have `.beads/` committed (complements GitHub Issues; does not replace it).
 - See #39.

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -9,7 +9,7 @@ See also:
 
 ## 1. Program overview
 
-`neuromod` hosts shared traits and core SNN contracts for the org (no separate traits crate).
+`neuromod` hosts foundational SNN and neuromodulation contracts (plus core shared traits) for the org (no separate traits crate).
 
 The org maintains ~22 repositories (Rust crates for core infrastructure + Julia research layers + one hardware HDL repo). Hard boundaries are enforced so each owns one layer.
 
@@ -23,21 +23,21 @@ Why `neuromod` for shared traits:
 
 | Issue | Phase    | Summary |
 |-------|----------|---------|
-| #35   | Traits   | Audit trait boundaries across org |
-| #36   | Traits   | Design trait API contract |
-| #37   | Traits   | Implement traits in neuromod |
-| #43   | Traits   | ADR: traits live in neuromod |
-| #38   | Deps     | Fix git dependency URLs |
-| #42   | Deps     | Remove pinned `rev` pins |
-| #40   | Build    | Validate neuromod release profile |
-| #41   | Build    | Roll out release profiles org-wide |
-| #39   | Tooling  | Initialize beads in missing repos |
+| [#35](https://github.com/Limen-Neural/neuromod/issues/35)   | Traits   | Audit trait boundaries across org |
+| [#36](https://github.com/Limen-Neural/neuromod/issues/36)   | Traits   | Design trait API contract |
+| [#37](https://github.com/Limen-Neural/neuromod/issues/37)   | Traits   | Implement traits in neuromod |
+| [#43](https://github.com/Limen-Neural/neuromod/issues/43)   | Traits   | ADR: traits live in neuromod |
+| [#38](https://github.com/Limen-Neural/neuromod/issues/38)   | Deps     | Fix git dependency URLs |
+| [#42](https://github.com/Limen-Neural/neuromod/issues/42)   | Deps     | Remove pinned `rev` pins |
+| [#40](https://github.com/Limen-Neural/neuromod/issues/40)   | Build    | Validate neuromod release profile |
+| [#41](https://github.com/Limen-Neural/neuromod/issues/41)   | Build    | Roll out release profiles org-wide |
+| [#39](https://github.com/Limen-Neural/neuromod/issues/39)   | Tooling  | Initialize beads in missing repos |
 
 (Full current list of open issues in the repo can be found via GitHub search.)
 
 ## 3. Execution order
 
-```
+```text
 Traits:  #35 → #36 → #37 → #43
 Deps:    #38 → #42
 Build:   #40 → #41
@@ -94,7 +94,7 @@ test -d .beads && echo OK || echo MISSING
 rg '^\[profile\.release\]' --glob '**/Cargo.toml' -A 3
 
 # Domain leakage in docs (CI guard)
-! grep -riE 'spikenaut|\bhft\b|\bmining\b|\bcrypto\b|eagle-lander' target/doc/<crate>/ || echo "leak"
+! grep -riE 'spikenaut|\bhft\b|\bmining\b|\bcrypto\b|eagle-lander' target/doc/<crate>/
 ```
 
 ## Related

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -44,7 +44,7 @@ Tooling: #39 (parallel)
 
 ## 4. Cross-cutting standards
 
-**Git dependencies**
+### Git dependencies
 
 - Inter-repo: `git = "https://github.com/Limen-Neural/<repo>", branch = "main"`
 - No pinned `rev` unless a documented exception with justification and removal plan.

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -13,6 +13,7 @@ See also:
 The org maintains ~22 repositories (Rust crates for core infrastructure + Julia research layers + one hardware HDL repo). Hard boundaries are enforced so each owns one layer.
 
 Why `neuromod` for shared traits:
+
 - Lowest layer for neuron dynamics, network stepping, generic neuromodulation, and plasticity primitives.
 - Already depended on (directly or indirectly) by runtime, training, relay, and hybrid crates.
 - Avoids extra repo overhead and duplication risk.

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -1,0 +1,105 @@
+# Org Modularization Standards and Issue Index
+
+This document is the durable, in-repo reference for the Limen-Neural modularization program. It replaces scattered GitHub issue threads as the canonical place maintainers and agents consult.
+
+See also:
+- `docs/neuromod-boundary-matrix.md`
+- `docs/adr/001-traits-in-neuromod.md`
+
+## 1. Program overview
+
+`neuromod` hosts shared traits and core SNN contracts for the org (no separate traits crate).
+
+The org maintains ~22 repositories (Rust crates for core infrastructure + Julia research layers + one hardware HDL repo). Hard boundaries are enforced so each owns one layer.
+
+Why `neuromod` for shared traits:
+- Lowest layer for neuron dynamics, network stepping, generic neuromodulation, and plasticity primitives.
+- Already depended on (directly or indirectly) by runtime, training, relay, and hybrid crates.
+- Avoids extra repo overhead and duplication risk.
+
+## 2. Workstream index
+
+| Issue | Phase    | Summary |
+|-------|----------|---------|
+| #35   | Traits   | Audit trait boundaries across org |
+| #36   | Traits   | Design trait API contract |
+| #37   | Traits   | Implement traits in neuromod |
+| #43   | Traits   | ADR: traits live in neuromod |
+| #38   | Deps     | Fix git dependency URLs |
+| #42   | Deps     | Remove pinned `rev` pins |
+| #40   | Build    | Validate neuromod release profile |
+| #41   | Build    | Roll out release profiles org-wide |
+| #39   | Tooling  | Initialize beads in missing repos |
+
+(Full current list of open issues in the repo can be found via GitHub search.)
+
+## 3. Execution order
+
+```
+Traits:  #35 → #36 → #37 → #43
+Deps:    #38 → #42
+Build:   #40 → #41
+Tooling: #39 (parallel)
+```
+
+## 4. Cross-cutting standards
+
+**Git dependencies**
+
+- Inter-repo: `git = "https://github.com/Limen-Neural/<repo>", branch = "main"`
+- No pinned `rev` unless a documented exception with justification and removal plan.
+- Prefer version pins once crates are published to crates.io.
+- Example (good):
+  ```toml
+  neuromod = { git = "https://github.com/Limen-Neural/neuromod", branch = "main" }
+  ```
+- Current examples of pinned usage (to be cleaned by #42 work) exist in plasticity-lab, etc.
+
+**Release profile template**
+
+Every active Rust crate should include:
+
+```toml
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+```
+
+(This is already present in `neuromod/Cargo.toml` and was validated under #40.)
+
+**Beads**
+
+- Every active org repo should have `.beads/` committed (complements GitHub Issues; does not replace it).
+- See #39.
+
+## 5. Audit commands (copy-paste)
+
+```bash
+# Pinned revisions (should be rare)
+rg 'rev\s*=' --glob '**/Cargo.toml'
+
+# Git dependencies
+rg 'git\s*=' --glob '**/Cargo.toml'
+
+# Trait definitions (to audit surface)
+rg '^(pub\s+)?trait\s+' --glob 'src/**/*.rs'
+
+# Beads presence
+test -d .beads && echo OK || echo MISSING
+
+# Release profile
+rg '^\[profile\.release\]' --glob '**/Cargo.toml' -A 3
+
+# Domain leakage in docs (CI guard)
+! grep -riE 'spikenaut|\bhft\b|\bmining\b|\bcrypto\b|eagle-lander' target/doc/<crate>/ || echo "leak"
+```
+
+## Related
+
+- Parent: this doc was extracted from the body of #44.
+- Siblings: #35–#43.
+- Boundary matrix and ADR live alongside this file.
+- Org repo inventory (as of 2026-07): axon-encoder, neuromod, synaptic-mesh, kinetic-signals, corpus-ipc, silicon-bridge, thalamic-relay, limbic-critic, engram-parser, cortex-tensor, plasticity-lab, metabolic-ledger, brainstem-daemon, hybrid-fusion, silicon-hdl, plus Julia crates and Spikenaut-Hardware.
+
+Update this document as child issues complete.

--- a/docs/org-modularization.md
+++ b/docs/org-modularization.md
@@ -3,6 +3,7 @@
 This document is the durable, in-repo reference for the Limen-Neural modularization program. It replaces scattered GitHub issue threads as the canonical place maintainers and agents consult.
 
 See also:
+
 - `docs/neuromod-boundary-matrix.md`
 - `docs/adr/001-traits-in-neuromod.md`
 


### PR DESCRIPTION
Addresses #11, #25, #43, #44.

- docs/neuromod-boundary-matrix.md (runtime/deployment boundary matrix per LIM-9)
- docs/adr/001-traits-in-neuromod.md (shared traits decision)
- docs/org-modularization.md (standards + workstream index for #35-43)
- README.md: new Architecture & Boundaries section with links
- CHANGELOG.md: entry under Unreleased

Docs-only changes. No src modifications. Follows exact specs from the issues and org boundary patterns from sibling repos.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new architecture and boundary guidance covering core responsibilities, repo modularization, and runtime/deployment boundaries.
  * Expanded the README with an “Architecture & Boundaries” section and updated CI guidance.
* **Chores**
  * Updated release notes to reflect the license change to dual MIT/Apache-2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

