### PR TITLE
chore: bench harness docs, publish readiness, sentry example hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # AI Tool Local/Ephemeral (no clutter)
-.kilo/worktrees/
-.kilo/*.json
+.kilo/
+.kilocode/
+.mimocode/
 .devin/cache/
-.mimocode/auth.json
-.mimocode/plans/
 .worktrees/
 .swarm/
 .beads/
@@ -11,7 +10,6 @@
 .claude/
 .codex/
 .opencode/
-.beads/
 
 
 # Compiled output

--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,10 @@
 .zed/
 
 # Standard dev + your data
-node_modules/
-dist/
-build/
 *.log
 .env*
 *.env
+!.env.example
 __pycache__/
 .cache/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 # AI Tool Local/Ephemeral (no clutter)
-.kilo/
+# Use `dir/*` + selective re-includes so parent-dir ignores do not block exceptions.
+.kilo/*
+!.kilo/skills/
+!.kilo/skills/**
+!.kilo/tui.jsonc
 .kilocode/
-.mimocode/
+.mimocode/*
+!.mimocode/mimocode.jsonc
+!.mimocode/AGENTS.md
 .devin/cache/
 .worktrees/
 .swarm/
@@ -38,9 +44,5 @@ neuromorphic_data/
 remotes.txt
 
 # Negations: Force-commit the good stuff
-!.kilo/skills/**
-!.kilo/tui.jsonc
 !.devin/blueprint.yaml
-!.mimocode/mimocode.jsonc
-!.mimocode/AGENTS.md
 !.kilocodeignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,48 @@
-/target
-*.crate
+# AI Tool Local/Ephemeral (no clutter)
+.kilo/worktrees/
+.kilo/*.json
+.devin/cache/
+.mimocode/auth.json
+.mimocode/plans/
+.worktrees/
+.swarm/
+.beads/
+.cline/
+.claude/
+.codex/
+.opencode/
+.beads/
 
-# Rust build
+
+# Compiled output
 /target/
+
+# IDE / editor
 .idea/
-.kilo/
-.kilocode/
-.mimocode/
+.vscode/
+*.swp
+*~
+.cursor/
+.cursorignore
+.zed/
+
+# Standard dev + your data
+node_modules/
+dist/
+build/
+*.log
+.env*
+*.env
+__pycache__/
+.cache/
+.DS_Store
+neuromorphic_data/
+remotes.txt
+
+# Negations: Force-commit the good stuff
+!.kilo/skills/**
+!.kilo/tui.jsonc
+!.devin/blueprint.yaml
+!.mimocode/mimocode.jsonc
+!.mimocode/AGENTS.md
+!.kilocodeignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project are documented in this file.
 - README now links the new Architecture & Boundaries docs.
 - Added `homepage` and `documentation` fields to `Cargo.toml` for crates.io/docs.rs metadata.
 - Explicit `[profile.bench]` inherits `release` so Criterion runs with the same LTO/codegen settings.
+- Dropped unused direct `serde_json` dependency (serialization uses `serde` derives only).
 
 ## [0.5.0] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project are documented in this file.
 - **Benchmarks:** all four `[[bench]]` targets (`neuron_bench`, `stdp_bench`, `memory_bench`, `modulation_bench`) had `harness = true` in `Cargo.toml`, which left Cargo's default libtest harness attached instead of Criterion's runner — `cargo bench` silently reported `running 0 tests` instead of executing any benchmark. Fixed to `harness = false`.
 - Removed first-person development-log commentary from `src/rm_stdp.rs` doc comments that leaked into `cargo doc`/docs.rs output.
 - **Sentry example:** dropped the info-level `capture_message` probe (issue noise) and set `environment` from `SENTRY_ENVIRONMENT` (default `development`).
+- **PoissonEncoder:** full-intensity (probability 1.0) and zero-intensity paths no longer depend on floating-point RNG bounds (avoids flaky all-ones encoding).
+- **`.gitignore`:** restructured AI-tool ignores so selected `.kilo` / `.mimocode` / `.devin` paths can be force-committed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ All notable changes to this project are documented in this file.
 
 - **Benchmarks:** all four `[[bench]]` targets (`neuron_bench`, `stdp_bench`, `memory_bench`, `modulation_bench`) had `harness = true` in `Cargo.toml`, which left Cargo's default libtest harness attached instead of Criterion's runner — `cargo bench` silently reported `running 0 tests` instead of executing any benchmark. Fixed to `harness = false`.
 - Removed first-person development-log commentary from `src/rm_stdp.rs` doc comments that leaked into `cargo doc`/docs.rs output.
+- **Sentry example:** dropped the info-level `capture_message` probe (issue noise) and set `environment` from `SENTRY_ENVIRONMENT` (default `development`).
 
 ### Changed
 
 - **License:** switched from GPL-3.0 to dual MIT/Apache-2.0 for maximum adoption and ecosystem health.
 - README now links the new Architecture & Boundaries docs.
 - Added `homepage` and `documentation` fields to `Cargo.toml` for crates.io/docs.rs metadata.
+- Explicit `[profile.bench]` inherits `release` so Criterion runs with the same LTO/codegen settings.
 
 ## [0.5.0] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,20 @@ All notable changes to this project are documented in this file.
   - `docs/org-modularization.md` (standards, workstream index for #35–#43, git/build/beads rules, audit commands)
   - `docs/adr/001-traits-in-neuromod.md` (records decision to host shared traits in neuromod)
   - `docs/neuromod-boundary-matrix.md` (runtime/deployment boundary matrix per LIM-9 / #11 / #25)
+- `CLAUDE.md` architecture/commands reference for AI coding agents.
+- Unit tests for `EligibilityTrace::decay` (`src/rm_stdp.rs`) and `LifNeuron`/`PoissonEncoder` (`src/lif.rs`), previously untested.
+- `REVIEW.md` regression guard against the Criterion benchmark harness reverting to `harness = true`.
+
+### Fixed
+
+- **Benchmarks:** all four `[[bench]]` targets (`neuron_bench`, `stdp_bench`, `memory_bench`, `modulation_bench`) had `harness = true` in `Cargo.toml`, which left Cargo's default libtest harness attached instead of Criterion's runner — `cargo bench` silently reported `running 0 tests` instead of executing any benchmark. Fixed to `harness = false`.
+- Removed first-person development-log commentary from `src/rm_stdp.rs` doc comments that leaked into `cargo doc`/docs.rs output.
 
 ### Changed
 
 - **License:** switched from GPL-3.0 to dual MIT/Apache-2.0 for maximum adoption and ecosystem health.
 - README now links the new Architecture & Boundaries docs.
+- Added `homepage` and `documentation` fields to `Cargo.toml` for crates.io/docs.rs metadata.
 
 ## [0.5.0] - 2026-06-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Returns the indices of LIF neurons that fired this step.
 
 - **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
 - **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`. The live per-step learning rule is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine.
-- That path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
+- The R-STDP engine path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
 
 ### Neuromodulators are domain-agnostic by design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Identity
+
+You are a Rust contributor to `neuromod`, a foundational spiking neural network (SNN) neuron-dynamics crate in the Limen-Neural ecosystem. Prefer concrete commands and file references over speculation. For the full agent brief (repo map, boundaries, PR conventions), read [AGENTS.md](AGENTS.md) before structural changes. This file focuses on commands and architecture.
+
 ## Project
 
-`neuromod` is a Rust library crate (edition 2024) implementing biologically grounded spiking neural network (SNN) primitives: neuron models, a topology-neutral `SpikingNetwork` engine, generic `NeuroModulators`, and reward-modulated plasticity building blocks. It is the core library layer of the Limen-Neural ecosystem — see `AGENTS.md` for the full agent brief (identity, repo map, boundaries, PR conventions) and `docs/neuromod-boundary-matrix.md` / `docs/org-modularization.md` for cross-repo ownership rules. Read `AGENTS.md` before making structural changes; this file focuses on commands and architecture.
+`neuromod` is a Rust library crate (edition 2024). It implements biologically grounded SNN primitives: neuron models, a topology-neutral `SpikingNetwork` engine, generic `NeuroModulators`, and reward-modulated plasticity building blocks. It is the core library layer of the Limen-Neural ecosystem.
 
-**Off-limits in this crate:** no async, networking, or hardware-specific code; no mining/trading/HFT/crypto domain logic. Downstream crates (`axon-encoder`, `synaptic-mesh`, `limbic-critic`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `silicon-bridge`, `Spikenaut-Hardware`) own everything outside neuron dynamics/neuromodulation/plasticity.
+Ownership rules: [docs/neuromod-boundary-matrix.md](docs/neuromod-boundary-matrix.md) and [docs/org-modularization.md](docs/org-modularization.md).
+
+**Off-limits in this crate:** no async, networking, or hardware-specific code. No mining, trading, high-frequency trading (HFT), or crypto domain logic. Downstream crates (`axon-encoder`, `synaptic-mesh`, `limbic-critic`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `silicon-bridge`, `Spikenaut-Hardware`) own everything outside neuron dynamics, neuromodulation, and plasticity.
 
 ## Commands
 
@@ -44,22 +50,24 @@ cargo run --example rstdp_demo
 SENTRY_DSN=https://...@... cargo run --example sentry --features sentry
 ```
 
-Before pushing changes touching `src/`, `benches/`, `examples/`, `tests/`, or `Cargo.toml`, run the full gate in `REVIEW.md` (fmt, clippy, build, test, examples smoke, docs domain-hygiene grep, regression grep for the public API surface).
+Before pushing changes that touch `src/`, `benches/`, `examples/`, `tests/`, or `Cargo.toml`, run the full gate in [REVIEW.md](REVIEW.md). That gate covers fmt, clippy, build, test, examples smoke, docs domain-hygiene grep, and public-API regression greps.
 
-The toolchain is pinned in `rust-toolchain.toml` (1.97.1); a matching `.devcontainer/` is available (`devcontainer up --workspace-folder .`).
+The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.97.1). A matching `.devcontainer/` is available (`devcontainer up --workspace-folder .`).
 
 ## Architecture
 
 ### Two neuron banks driven by one engine
 
-`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks — `neurons: Vec<LifNeuron>` and `iz_neurons: Vec<IzhikevichNeuron>` — plus a `NeuroModulators` snapshot, a `global_step` counter, and per-channel STDP/prediction state (`input_spike_times`, `predictive_state`). It is constructed topology-neutral: `new()` gives the legacy default (16 LIF, 5 Izhikevich, 16 channels), `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights — no domain topology is hardcoded.
+`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks: `neurons: Vec<LifNeuron>` and `iz_neurons: Vec<IzhikevichNeuron>`. It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
 
-`SpikingNetwork::step(stimuli, modulators)` is the single per-tick entry point and always runs, in order:
+Construction is topology-neutral. `new()` is the legacy default (16 LIF, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
+
+`SpikingNetwork::step(stimuli, modulators)` is the normal per-tick entry point for the default engine. Prefer it for full-network simulation; call lower-level neuron APIs only when testing or embedding a single model. Order of work inside `step`:
 
 1. Validate `stimuli.len() == num_channels`, else `Err(StepError::InputLenMismatch)`.
-2. Recompute per-neuron `decay_rate`/`threshold` targets from the current `NeuroModulators` (dopamine/serotonin/acetylcholine/norepinephrine each pull thresholds/decay in different directions — see the formulas inline in `engine.rs`).
-3. Update `predictive_state` (EMA per channel) and derive `pred_errors` ("surprise") that boost synaptic drive.
-4. Stochastically encode `stimuli` into `input_spike_times` (Poisson-style, probability ∝ stimulus magnitude).
+2. Recompute per-neuron `decay_rate`/`threshold` targets from the current `NeuroModulators` (dopamine/serotonin/acetylcholine/norepinephrine each pull thresholds/decay in different directions — see formulas in `engine.rs`).
+3. Update `predictive_state` (exponential moving average (EMA) per channel) and derive `pred_errors` ("surprise") that boost synaptic drive.
+4. Stochastically encode `stimuli` into `input_spike_times` (Poisson-style, probability proportional to stimulus magnitude).
 5. Integrate LIF membrane potentials, fire (`check_fire`), apply lateral inhibition to non-firing LIF neurons.
 6. Apply reward-modulated STDP (`apply_stdp`, gated by `dopamine`-derived `learning_rate`; skipped entirely if learning rate ≈ 0).
 7. Re-normalize each neuron's weights to `WEIGHT_BUDGET` (L1 budget) and clamp to `RM_STDP_W_MIN..RM_STDP_W_MAX`.
@@ -67,22 +75,28 @@ The toolchain is pinned in `rust-toolchain.toml` (1.97.1); a matching `.devconta
 
 Returns the indices of LIF neurons that fired this step.
 
-### Two separate STDP implementations — don't conflate them
+### Two separate STDP implementations — do not conflate them
 
 - **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
-- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`, but the actual per-step learning rule that consumes them is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine. Per `rm_stdp.rs`'s own comments, this reward-modulated path was reconstructed after being found missing from the original codebase — `EligibilityTrace` exists but is not yet wired into `apply_stdp`; weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Be aware of this gap before assuming eligibility traces are live.
+- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`. The live per-step learning rule is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine. That path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
 
 ### Neuromodulators are domain-agnostic by design
 
-`NeuroModulators` (`src/modulators.rs`) is a plain 4-tuple (dopamine/serotonin/acetylcholine/norepinephrine) with its own exponential `decay()` and `add_*`/`boost_*`/`is_*` helpers. Domain signals (thermal, power, throughput, timing) are mapped into modulator levels via `SignalProfile` + `NeuroModulators::from_signals(...)` — `SignalProfile::default()` is unitless/neutral, `SignalProfile::hardware_calibrated()` is a legacy pre-0.5 profile kept for migration. Reward shaping for a specific domain is implemented downstream via the `GenericReward` trait (`UnitReward` is the only in-crate impl, used for tests). `apply_neuromodulation` applies a `NeuroModulators` snapshot to arbitrary weight/threshold slices independent of `SpikingNetwork`.
+`NeuroModulators` (`src/modulators.rs`) is a plain 4-tuple (dopamine/serotonin/acetylcholine/norepinephrine) with exponential `decay()` and `add_*`/`boost_*`/`is_*` helpers.
+
+Domain signals (thermal, power, throughput, timing) map into modulator levels via `SignalProfile` and `NeuroModulators::from_signals(...)`. `SignalProfile::default()` is unitless/neutral. `SignalProfile::hardware_calibrated()` is a legacy pre-0.5 profile kept for migration.
+
+Domain-specific reward shaping is downstream via the `GenericReward` trait. `UnitReward` is the only in-crate impl (tests). `apply_neuromodulation` applies a `NeuroModulators` snapshot to weight/threshold slices without needing `SpikingNetwork`.
 
 ### Neuron models are standalone structs, not a shared trait
 
-Each neuron model (`LifNeuron`, `GifNeuron`, `IzhikevichNeuron`, `LapicqueNeuron`, `FitzHughNagumoNeuron`, `HodgkinHuxleyNeuron`) is its own `Serialize`/`Deserialize` struct in its own file under `src/`, with its own `integrate`/`step`/`check_fire`-style API — there is no shared `Neuron` trait unifying them (see `docs/adr/001-traits-in-neuromod.md` for why shared traits are hosted in this crate at all). Only `LifNeuron` and `IzhikevichNeuron` are wired into `SpikingNetwork`; the others are standalone building blocks for downstream consumers/examples.
+Each neuron model (`LifNeuron`, `GifNeuron`, `IzhikevichNeuron`, `LapicqueNeuron`, `FitzHughNagumoNeuron`, `HodgkinHuxleyNeuron`) is its own `Serialize`/`Deserialize` struct under `src/`, with its own `integrate`/`step`/`check_fire`-style API. There is no shared `Neuron` trait (see [docs/adr/001-traits-in-neuromod.md](docs/adr/001-traits-in-neuromod.md)).
+
+Only `LifNeuron` and `IzhikevichNeuron` are wired into `SpikingNetwork`. The others are standalone building blocks for downstream consumers and examples.
 
 ### Serialization
 
-`SpikingNetwork` and its neuron banks derive `Serialize`/`Deserialize` (serde) for checkpointing; fields added after the initial release use `#[serde(default)]` (e.g. `LifNeuron::weights`, `base_threshold`, `last_spike_time`) to stay backward-compatible with older serialized states.
+`SpikingNetwork` and its neuron banks derive `Serialize`/`Deserialize` (serde) for checkpointing. Fields added after the initial release use `#[serde(default)]` (for example `LifNeuron::weights`, `base_threshold`, `last_spike_time`) so older serialized states still load.
 
 ### Optional `sentry` feature
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`neuromod` is a Rust library crate (edition 2024) implementing biologically grounded spiking neural network (SNN) primitives: neuron models, a topology-neutral `SpikingNetwork` engine, generic `NeuroModulators`, and reward-modulated plasticity building blocks. It is the core library layer of the Limen-Neural ecosystem — see `AGENTS.md` for the full agent brief (identity, repo map, boundaries, PR conventions) and `docs/neuromod-boundary-matrix.md` / `docs/org-modularization.md` for cross-repo ownership rules. Read `AGENTS.md` before making structural changes; this file focuses on commands and architecture.
+
+**Off-limits in this crate:** no async, networking, or hardware-specific code; no mining/trading/HFT/crypto domain logic. Downstream crates (`axon-encoder`, `synaptic-mesh`, `limbic-critic`, `plasticity-lab`, `corpus-ipc`, `brainstem-daemon`, `silicon-bridge`, `Spikenaut-Hardware`) own everything outside neuron dynamics/neuromodulation/plasticity.
+
+## Commands
+
+```bash
+# Build
+cargo build                    # default (no optional features)
+cargo build --all-features     # includes `sentry`
+
+# Test (unit + doctests; crate-level example in src/lib.rs runs as a doctest)
+cargo test
+cargo test --all-features      # also runs tests/sentry_integration.rs (16 tests)
+
+# Single test
+cargo test <test_name>
+cargo test --package neuromod <module>::tests::<test_name>
+
+# Lint / format (CI fails on any warning)
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Feature-powerset matrix (as run in CI)
+cargo hack check --feature-powerset --exclude-no-default-features --keep-going
+
+# Coverage (matches codecov.yml)
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+# Benchmarks (Criterion; compile-only smoke)
+cargo bench --no-run --all-features
+
+# Examples
+cargo run --example basic
+cargo run --example basic_lif
+cargo run --example hebbian_learning
+cargo run --example rstdp_demo
+SENTRY_DSN=https://...@... cargo run --example sentry --features sentry
+```
+
+Before pushing changes touching `src/`, `benches/`, `examples/`, `tests/`, or `Cargo.toml`, run the full gate in `REVIEW.md` (fmt, clippy, build, test, examples smoke, docs domain-hygiene grep, regression grep for the public API surface).
+
+The toolchain is pinned in `rust-toolchain.toml` (1.97.1); a matching `.devcontainer/` is available (`devcontainer up --workspace-folder .`).
+
+## Architecture
+
+### Two neuron banks driven by one engine
+
+`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks — `neurons: Vec<LifNeuron>` and `iz_neurons: Vec<IzhikevichNeuron>` — plus a `NeuroModulators` snapshot, a `global_step` counter, and per-channel STDP/prediction state (`input_spike_times`, `predictive_state`). It is constructed topology-neutral: `new()` gives the legacy default (16 LIF, 5 Izhikevich, 16 channels), `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights — no domain topology is hardcoded.
+
+`SpikingNetwork::step(stimuli, modulators)` is the single per-tick entry point and always runs, in order:
+
+1. Validate `stimuli.len() == num_channels`, else `Err(StepError::InputLenMismatch)`.
+2. Recompute per-neuron `decay_rate`/`threshold` targets from the current `NeuroModulators` (dopamine/serotonin/acetylcholine/norepinephrine each pull thresholds/decay in different directions — see the formulas inline in `engine.rs`).
+3. Update `predictive_state` (EMA per channel) and derive `pred_errors` ("surprise") that boost synaptic drive.
+4. Stochastically encode `stimuli` into `input_spike_times` (Poisson-style, probability ∝ stimulus magnitude).
+5. Integrate LIF membrane potentials, fire (`check_fire`), apply lateral inhibition to non-firing LIF neurons.
+6. Apply reward-modulated STDP (`apply_stdp`, gated by `dopamine`-derived `learning_rate`; skipped entirely if learning rate ≈ 0).
+7. Re-normalize each neuron's weights to `WEIGHT_BUDGET` (L1 budget) and clamp to `RM_STDP_W_MIN..RM_STDP_W_MAX`.
+8. Drive the Izhikevich bank from the mean LIF membrane potential + dopamine (`iz_drive`), independent of the LIF spike/STDP pipeline.
+
+Returns the indices of LIF neurons that fired this step.
+
+### Two separate STDP implementations — don't conflate them
+
+- **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
+- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`, but the actual per-step learning rule that consumes them is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine. Per `rm_stdp.rs`'s own comments, this reward-modulated path was reconstructed after being found missing from the original codebase — `EligibilityTrace` exists but is not yet wired into `apply_stdp`; weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Be aware of this gap before assuming eligibility traces are live.
+
+### Neuromodulators are domain-agnostic by design
+
+`NeuroModulators` (`src/modulators.rs`) is a plain 4-tuple (dopamine/serotonin/acetylcholine/norepinephrine) with its own exponential `decay()` and `add_*`/`boost_*`/`is_*` helpers. Domain signals (thermal, power, throughput, timing) are mapped into modulator levels via `SignalProfile` + `NeuroModulators::from_signals(...)` — `SignalProfile::default()` is unitless/neutral, `SignalProfile::hardware_calibrated()` is a legacy pre-0.5 profile kept for migration. Reward shaping for a specific domain is implemented downstream via the `GenericReward` trait (`UnitReward` is the only in-crate impl, used for tests). `apply_neuromodulation` applies a `NeuroModulators` snapshot to arbitrary weight/threshold slices independent of `SpikingNetwork`.
+
+### Neuron models are standalone structs, not a shared trait
+
+Each neuron model (`LifNeuron`, `GifNeuron`, `IzhikevichNeuron`, `LapicqueNeuron`, `FitzHughNagumoNeuron`, `HodgkinHuxleyNeuron`) is its own `Serialize`/`Deserialize` struct in its own file under `src/`, with its own `integrate`/`step`/`check_fire`-style API — there is no shared `Neuron` trait unifying them (see `docs/adr/001-traits-in-neuromod.md` for why shared traits are hosted in this crate at all). Only `LifNeuron` and `IzhikevichNeuron` are wired into `SpikingNetwork`; the others are standalone building blocks for downstream consumers/examples.
+
+### Serialization
+
+`SpikingNetwork` and its neuron banks derive `Serialize`/`Deserialize` (serde) for checkpointing; fields added after the initial release use `#[serde(default)]` (e.g. `LifNeuron::weights`, `base_threshold`, `last_spike_time`) to stay backward-compatible with older serialized states.
+
+### Optional `sentry` feature
+
+Off by default (`features = []`). When enabled, adds error/panic reporting (`sentry` crate, rustls transport) — see `examples/sentry.rs` and `tests/sentry_integration.rs`. Requires `pkg-config`/`libssl-dev` system deps only when building with this feature.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,9 @@ The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.97.1). 
 
 ### Two neuron banks driven by one engine
 
-`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks: `neurons: Vec<LifNeuron>` and `iz_neurons: Vec<IzhikevichNeuron>`. It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
+`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks: leaky integrate-and-fire (LIF) neurons (`neurons: Vec<LifNeuron>`) and Izhikevich neurons (`iz_neurons: Vec<IzhikevichNeuron>`). It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
 
-Construction is topology-neutral. `new()` is the legacy default (16 leaky integrate-and-fire (LIF) neurons, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
+Construction is topology-neutral. `new()` is the legacy default (16 LIF, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
 
 `SpikingNetwork::step(stimuli, modulators)` is the normal per-tick entry point for the default engine. Prefer it for full-network simulation; call lower-level neuron APIs only when testing or embedding a single model. Order of work inside `step`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Identity
 
-You are a Rust contributor to `neuromod`, a foundational spiking neural network (SNN) neuron-dynamics crate in the Limen-Neural ecosystem. Prefer concrete commands and file references over speculation. For the full agent brief (repo map, boundaries, PR conventions), read [AGENTS.md](AGENTS.md) before structural changes. This file focuses on commands and architecture.
+You are a Rust contributor to `neuromod`, a foundational spiking neural network (SNN) neuron-dynamics crate in the Limen-Neural ecosystem. Prefer concrete commands and file references over speculation.
+
+For the full agent brief (repo map, boundaries, PR conventions), read [AGENTS.md](AGENTS.md) before structural changes. This file focuses on commands and architecture.
 
 ## Project
 
@@ -60,7 +62,7 @@ The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.97.1). 
 
 `SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks: `neurons: Vec<LifNeuron>` and `iz_neurons: Vec<IzhikevichNeuron>`. It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
 
-Construction is topology-neutral. `new()` is the legacy default (16 LIF, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
+Construction is topology-neutral. `new()` is the legacy default (16 leaky integrate-and-fire (LIF) neurons, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
 
 `SpikingNetwork::step(stimuli, modulators)` is the normal per-tick entry point for the default engine. Prefer it for full-network simulation; call lower-level neuron APIs only when testing or embedding a single model. Order of work inside `step`:
 
@@ -78,7 +80,8 @@ Returns the indices of LIF neurons that fired this step.
 ### Two separate STDP implementations — do not conflate them
 
 - **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
-- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`. The live per-step learning rule is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine. That path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
+- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`. The live per-step learning rule is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine.
+- That path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
 
 ### Neuromodulators are domain-agnostic by design
 
@@ -100,4 +103,4 @@ Only `LifNeuron` and `IzhikevichNeuron` are wired into `SpikingNetwork`. The oth
 
 ### Optional `sentry` feature
 
-Off by default (`features = []`). When enabled, adds error/panic reporting (`sentry` crate, rustls transport) — see `examples/sentry.rs` and `tests/sentry_integration.rs`. Requires `pkg-config`/`libssl-dev` system deps only when building with this feature.
+Off by default (`features = []`). When enabled, adds error/panic reporting (`sentry` crate, rustls transport). See the [examples/sentry.rs](examples/sentry.rs) example and [tests/sentry_integration.rs](tests/sentry_integration.rs) integration tests. Requires `pkg-config`/`libssl-dev` system deps only when building with this feature.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@ The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.97.1). 
 
 ### Two neuron banks driven by one engine
 
-`SpikingNetwork` (`src/engine.rs`) is the central struct. It owns two parallel neuron banks: leaky integrate-and-fire (LIF) neurons (`neurons: Vec<LifNeuron>`) and Izhikevich neurons (`iz_neurons: Vec<IzhikevichNeuron>`). It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
+`SpikingNetwork` (`src/engine.rs`) is the central struct.
+
+It owns two parallel neuron banks: leaky integrate-and-fire (LIF) neurons (`neurons: Vec<LifNeuron>`) and Izhikevich neurons (`iz_neurons: Vec<IzhikevichNeuron>`).
+
+It also holds a `NeuroModulators` snapshot, a `global_step` counter, and per-channel spike-timing-dependent plasticity (STDP) / prediction state (`input_spike_times`, `predictive_state`).
 
 Construction is topology-neutral. `new()` is the legacy default (16 LIF, 5 Izhikevich, 16 channels). `with_dimensions(num_lif, num_izh, num_channels)` builds arbitrary sizes with blank synaptic weights. No domain topology is hardcoded.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,11 @@ Returns the indices of LIF neurons that fired this step.
 
 ### Neuromodulators are domain-agnostic by design
 
-`NeuroModulators` (`src/modulators.rs`) is a plain 4-tuple (dopamine/serotonin/acetylcholine/norepinephrine) with exponential `decay()` and `add_*`/`boost_*`/`is_*` helpers.
+`NeuroModulators` (`src/modulators.rs`) is a four-field struct (dopamine/serotonin/acetylcholine/norepinephrine) with exponential `decay()` and `add_*`/`boost_*`/`is_*` helpers.
 
 Domain signals (thermal, power, throughput, timing) map into modulator levels via `SignalProfile` and `NeuroModulators::from_signals(...)`. `SignalProfile::default()` is unitless/neutral. `SignalProfile::hardware_calibrated()` is a legacy pre-0.5 profile kept for migration.
 
-Domain-specific reward shaping is downstream via the `GenericReward` trait. `UnitReward` is the only in-crate impl (tests). `apply_neuromodulation` applies a `NeuroModulators` snapshot to weight/threshold slices without needing `SpikingNetwork`.
+Domain-specific reward shaping is downstream via the `GenericReward` trait. `UnitReward` is the only shipped implementation, intended for tests and simple consumer pipelines. `apply_neuromodulation` applies a `NeuroModulators` snapshot to weight/threshold slices without needing `SpikingNetwork`.
 
 ### Neuron models are standalone structs, not a shared trait
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,15 +64,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -80,14 +80,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -119,9 +120,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block2"
@@ -134,15 +135,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -152,9 +153,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -170,9 +171,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -214,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -318,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -337,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -359,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -391,7 +392,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -402,9 +403,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -424,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -472,9 +473,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -482,33 +483,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -539,11 +540,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -553,9 +552,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -629,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -639,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -664,9 +665,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -898,7 +899,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -917,34 +918,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -981,9 +983,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -996,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1030,7 +1032,6 @@ dependencies = [
  "rand 0.10.2",
  "sentry",
  "serde",
- "serde_json",
  "temp-env",
 ]
 
@@ -1263,7 +1264,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1414,18 +1415,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1443,15 +1444,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1465,23 +1467,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1500,9 +1502,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1545,10 +1547,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1575,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1587,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1598,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1661,15 +1672,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1695,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1723,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1772,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -1880,7 +1891,7 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -1918,7 +1929,7 @@ checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -1978,9 +1989,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2006,9 +2017,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2028,9 +2039,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2065,7 +2076,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2092,29 +2103,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2132,9 +2143,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2162,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2177,9 +2188,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2211,13 +2222,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2381,9 +2393,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -2429,18 +2441,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2451,23 +2463,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2475,31 +2483,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2517,18 +2525,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2576,16 +2584,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2603,31 +2602,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2637,22 +2619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2661,22 +2631,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2685,22 +2643,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2709,22 +2655,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -2757,28 +2691,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2798,7 +2732,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2838,11 +2772,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.151"
+serde_json = "1.0"
 rand = "0.10.1"
 sentry = { version = "0.48", optional = true, default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "transport"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ lto = true
 codegen-units = 1
 
 [profile.dev]
-opt-level = 1          # slightly faster debug builds
+opt-level = 1          # faster-running debug binaries
 incremental = true
 
 [profile.release-with-debug]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 rand = "0.10.1"
 sentry = { version = "0.48", optional = true, default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "transport"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ incremental = true
 [profile.release-with-debug]
 inherits = "release"
 debug = true           # for profiling release builds
+
+[profile.bench]
+inherits = "release"   # Criterion wall-clock benches use same LTO/codegen as release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "neuromod"
 version = "0.5.0"
 edition = "2024"
+rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"
 authors = ["Raul Montoya Cardenas <montoyaraul34@gmail.com>"]
 description = "A high-performance Rust SNN library for neuroscience research and pure spiking neural network library featuring LIF, Izhikevich, Hebbian, Nagumo, Lapicque and Hodgkin-Huxley dynamics."
@@ -10,6 +11,8 @@ repository = "https://github.com/Limen-Neural/neuromod"
 readme = "README.md"
 keywords = ["snn", "neuromorphic", "stdp", "spiking", "neuromodulation"]
 categories = ["science", "algorithms", "simulation"]
+homepage = "https://github.com/Limen-Neural/neuromod"
+documentation = "https://docs.rs/neuromod"
 
 [workspace]
 
@@ -19,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.151"
 rand = "0.10.1"
 sentry = { version = "0.48", optional = true, default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "transport"] }
 
@@ -52,3 +55,11 @@ sentry = ["dep:sentry"]
 opt-level = 3
 lto = true
 codegen-units = 1
+
+[profile.dev]
+opt-level = 1          # slightly faster debug builds
+incremental = true
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true           # for profiling release builds

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -47,6 +47,23 @@ cargo hack check --feature-powerset --exclude-no-default-features --keep-going
 cargo llvm-cov --all-features --lcov --output-path lcov.info
 ```
 
+## Local Qodana (before push)
+
+CLI: `qodana` (see `qodana.yaml`; CI twin is `.github/workflows/qodana_code_quality.yml`).
+
+```bash
+qodana scan --project-dir . --linter qodana-rust --print-problems --save-report
+```
+
+Optional Cloud upload if `QODANA_TOKEN` is set locally (never commit the token):
+
+```bash
+export QODANA_ENDPOINT=https://qodana.cloud
+qodana scan --project-dir . --linter qodana-rust --print-problems --save-report
+```
+
+Do not push while Qodana reports new actionable defects on `src/`, `examples/`, `benches/`, or `tests/`.
+
 ## Examples smoke
 
 ```bash

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -134,10 +134,22 @@ grep -R 'pub fn apply_classical_stdp\|pub fn apply_neuromodulation' src/
 grep -R 'pub struct EligibilityTrace\|pub struct RmStdpConfig' src/
 ```
 
-Verify Criterion benchmarks aren't silently reverted to the default libtest harness (causes `cargo bench` to report `running 0 tests` instead of executing benchmarks):
+Verify Criterion benchmarks aren't silently reverted to the default libtest harness (causes `cargo bench` to report `running 0 tests` instead of executing benchmarks). Every `[[bench]]` must explicitly set `harness = false` — omitting the key is as bad as setting `true`:
 
 ```bash
 ! grep -n 'harness = true' Cargo.toml
+# Fail if any [[bench]] lacks an explicit harness = false in the following lines
+python3 - <<'PY'
+from pathlib import Path
+text = Path("Cargo.toml").read_text()
+blocks = text.split("[[bench]]")[1:]
+assert blocks, "expected at least one [[bench]] target"
+for i, block in enumerate(blocks, 1):
+    # Only the next table section belongs to this bench target
+    section = block.split("\n[")[0]
+    assert "harness = false" in section, f"[[bench]] #{i} missing harness = false"
+print(f"ok: {len(blocks)} [[bench]] targets declare harness = false")
+PY
 ```
 
 ## Diff hygiene

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -57,6 +57,13 @@ cargo run --example rstdp_demo
 
 # Optional sentry example (no DSN needed for compilation smoke)
 cargo run --example sentry --features sentry
+
+# Release-mode smoke
+cargo run --example basic --release
+cargo run --example basic_lif --release
+cargo run --example hebbian_learning --release
+cargo run --example rstdp_demo --release
+cargo run --example sentry --release --features sentry
 ```
 
 ## Benchmarks smoke
@@ -64,6 +71,11 @@ cargo run --example sentry --features sentry
 ```bash
 # Compile benchmarks without running long measurements
 cargo bench --no-run --all-features
+
+# Benchmarks use harness = false (Criterion's own runner), so run them via
+# `cargo bench --bench <name>` in a terminal or a plain Cargo run
+# configuration in your IDE -- not a "Run Test" gutter action, which expects
+# the structured libtest protocol these targets don't emit.
 ```
 
 ## Docs and domain hygiene
@@ -97,6 +109,12 @@ grep -R 'pub struct NeuroModulators\|pub struct SignalProfile\|pub struct Observ
 grep -R 'pub trait GenericReward\|pub struct UnitReward' src/
 grep -R 'pub fn apply_classical_stdp\|pub fn apply_neuromodulation' src/
 grep -R 'pub struct EligibilityTrace\|pub struct RmStdpConfig' src/
+```
+
+Verify Criterion benchmarks aren't silently reverted to the default libtest harness (causes `cargo bench` to report `running 0 tests` instead of executing benchmarks):
+
+```bash
+! grep -n 'harness = true' Cargo.toml
 ```
 
 ## Diff hygiene

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -64,6 +64,12 @@ qodana scan --project-dir . --linter qodana-rust --print-problems --save-report
 
 Do not push while Qodana reports new actionable defects on `src/`, `examples/`, `benches/`, or `tests/`.
 
+**Known noise (do not block on these alone):**
+
+- `DuplicatedCode` in multi-stage RK4 integrators (`fitzhugh_nagumo`, `hodgkin_huxley`) — intentional stage structure.
+- `RsBorrowChecker` / `RsTypeCheck` false positives from incomplete Cargo project load in the Docker linter (host `cargo check` / `clippy -D warnings` is authoritative).
+- Prefer fixing real hits: unused deps (`CargoUnusedDependency`), clippy-equivalent nits.
+
 ## Examples smoke
 
 ```bash

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -147,7 +147,12 @@ assert blocks, "expected at least one [[bench]] target"
 for i, block in enumerate(blocks, 1):
     # Only the next table section belongs to this bench target
     section = block.split("\n[")[0]
-    assert "harness = false" in section, f"[[bench]] #{i} missing harness = false"
+    has_harness = any(
+        line.strip().startswith("harness") and "=" in line and "false" in line
+        for line in section.split("\n")
+        if not line.strip().startswith("#")
+    )
+    assert has_harness, f"[[bench]] #{i} missing active harness = false assignment"
 print(f"ok: {len(blocks)} [[bench]] targets declare harness = false")
 PY
 ```

--- a/benches/README.md
+++ b/benches/README.md
@@ -27,6 +27,13 @@ Compare with a previous baseline:
 cargo bench -- --baseline main
 ```
 
+> **IDE users:** these targets are declared with `harness = false` (required for
+> Criterion's own runner to execute at all). Run them via a terminal or a plain
+> **Cargo** run configuration. Don't use a "Run Test" / "Debug Test" gutter
+> action — that expects the structured libtest protocol, which `harness = false`
+> targets don't emit, and will fail with an IDE-side error (e.g. RustRover's
+> "test frame quit unexpectedly") even though `cargo bench` itself succeeds.
+
 ## Benchmark Suites
 
 ### 1. Neuron Benchmarks (`neuron_bench.rs`)

--- a/examples/sentry.rs
+++ b/examples/sentry.rs
@@ -24,7 +24,7 @@ fn main() {
                         parsed_dsn,
                         sentry::ClientOptions {
                             release: sentry::release_name!(),
-                            environment: Some(environment),
+                            environment: Some(environment.clone().into()),
                             ..Default::default()
                         },
                     ));

--- a/examples/sentry.rs
+++ b/examples/sentry.rs
@@ -24,7 +24,7 @@ fn main() {
                         parsed_dsn,
                         sentry::ClientOptions {
                             release: sentry::release_name!(),
-                            environment: Some(environment.clone().into()),
+                            environment: Some(environment),
                             ..Default::default()
                         },
                     ));

--- a/examples/sentry.rs
+++ b/examples/sentry.rs
@@ -2,7 +2,12 @@
 //!
 //! Run with: cargo run --features sentry --example sentry
 //!
-//! Set SENTRY_DSN environment variable to enable real reporting.
+//! Set `SENTRY_DSN` to enable real reporting. Optional `SENTRY_ENVIRONMENT`
+//! tags events (defaults to `development` so demo runs do not look like prod).
+//!
+//! This example only initializes the client and runs a normal neuromod step.
+//! It does **not** send info-level probe messages — those create issue noise
+//! (see instrumentation: errors at the edge only).
 
 fn main() {
     // Guarded initialization - only when the "sentry" feature is enabled.
@@ -13,17 +18,18 @@ fn main() {
             // Validate DSN before initialization
             match dsn.parse::<sentry::types::Dsn>() {
                 Ok(parsed_dsn) => {
+                    let environment = std::env::var("SENTRY_ENVIRONMENT")
+                        .unwrap_or_else(|_| "development".into());
                     let guard = sentry::init((
                         parsed_dsn,
                         sentry::ClientOptions {
                             release: sentry::release_name!(),
+                            environment: Some(environment.clone().into()),
                             ..Default::default()
                         },
                     ));
-                    println!("Sentry initialized for error monitoring (feature enabled)");
-                    sentry::capture_message(
-                        "Sentry integration active in neuromod example",
-                        sentry::Level::Info,
+                    println!(
+                        "Sentry initialized for error monitoring (feature enabled, env={environment})"
                     );
                     Some(guard)
                 }

--- a/src/lif.rs
+++ b/src/lif.rs
@@ -107,3 +107,89 @@ impl LifNeuron {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_neuron_has_expected_initial_state() {
+        let neuron = LifNeuron::new();
+        assert_eq!(neuron.membrane_potential, 0.0);
+        assert_eq!(neuron.decay_rate, 0.15);
+        assert_eq!(neuron.threshold, 0.02);
+        assert_eq!(neuron.base_threshold, 0.02);
+        assert!(!neuron.last_spike);
+        assert!(neuron.weights.is_empty());
+        assert_eq!(neuron.last_spike_time, -1);
+    }
+
+    #[test]
+    fn integrate_charges_then_leaks() {
+        let mut neuron = LifNeuron::new();
+        neuron.integrate(1.0);
+        let expected = 1.0 - 1.0 * neuron.decay_rate;
+        assert!((neuron.membrane_potential - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn integrate_accumulates_over_multiple_calls() {
+        let mut neuron = LifNeuron::new();
+        neuron.integrate(0.5);
+        neuron.integrate(0.5);
+        assert!(neuron.membrane_potential > 0.0);
+    }
+
+    #[test]
+    fn check_fire_below_threshold_returns_none_and_leaves_potential_unchanged() {
+        let mut neuron = LifNeuron::new();
+        neuron.membrane_potential = neuron.threshold - 0.01;
+        let before = neuron.membrane_potential;
+
+        assert_eq!(neuron.check_fire(), None);
+        assert_eq!(neuron.membrane_potential, before);
+    }
+
+    #[test]
+    fn check_fire_at_or_above_threshold_fires_and_hard_resets() {
+        let mut neuron = LifNeuron::new();
+        neuron.membrane_potential = neuron.threshold + 0.05;
+        let expected_peak = neuron.membrane_potential;
+
+        let fired = neuron.check_fire();
+
+        assert_eq!(fired, Some(expected_peak));
+        assert_eq!(neuron.membrane_potential, 0.0);
+    }
+
+    #[test]
+    fn poisson_encoder_zero_input_yields_all_zero_spike_train() {
+        let encoder = PoissonEncoder::new(50);
+        let spikes = encoder.encode(0.0);
+        assert_eq!(spikes.len(), 50);
+        assert!(spikes.iter().all(|&s| s == 0));
+    }
+
+    #[test]
+    fn poisson_encoder_negative_input_clamps_to_zero_spikes() {
+        let encoder = PoissonEncoder::new(20);
+        let spikes = encoder.encode(-5.0);
+        assert!(spikes.iter().all(|&s| s == 0));
+    }
+
+    #[test]
+    fn poisson_encoder_full_intensity_input_yields_all_ones() {
+        let encoder = PoissonEncoder::new(50);
+        let spikes = encoder.encode(1.0);
+        assert_eq!(spikes.len(), 50);
+        assert!(spikes.iter().all(|&s| s == 1));
+    }
+
+    #[test]
+    fn poisson_encoder_output_length_matches_num_steps() {
+        for steps in [0, 1, 10, 100] {
+            let encoder = PoissonEncoder::new(steps);
+            assert_eq!(encoder.encode(0.5).len(), steps);
+        }
+    }
+}

--- a/src/lif.rs
+++ b/src/lif.rs
@@ -27,11 +27,18 @@ impl PoissonEncoder {
             // Stochastic firing:
             // If the random number (0.0-1.0) is LESS than our intensity, we spike.
             // This mimics the noise inherent in quantum/chemical systems.
-            if rng.random_range(0.0..1.0) < probability {
-                spikes.push(1);
+            //
+            // Handle exact 0.0 / 1.0 without RNG: floating-point
+            // `random_range(0.0..1.0)` is not guaranteed to exclude 1.0, which
+            // would make full-intensity encoding flaky if compared with `< 1.0`.
+            let fire = if probability <= 0.0 {
+                false
+            } else if probability >= 1.0 {
+                true
             } else {
-                spikes.push(0);
-            }
+                rng.random_range(0.0..1.0) < probability
+            };
+            spikes.push(u8::from(fire));
         }
         spikes
     }

--- a/src/lif.rs
+++ b/src/lif.rs
@@ -28,9 +28,8 @@ impl PoissonEncoder {
             // If the random number (0.0-1.0) is LESS than our intensity, we spike.
             // This mimics the noise inherent in quantum/chemical systems.
             //
-            // Handle exact 0.0 / 1.0 without RNG: floating-point
-            // `random_range(0.0..1.0)` is not guaranteed to exclude 1.0, which
-            // would make full-intensity encoding flaky if compared with `< 1.0`.
+            // Handle exact 0.0 / 1.0 without RNG to make edge-case behavior
+            // explicit and avoid RNG calls for deterministic paths.
             let fire = if probability <= 0.0 {
                 false
             } else if probability >= 1.0 {
@@ -143,8 +142,10 @@ mod tests {
     fn integrate_accumulates_over_multiple_calls() {
         let mut neuron = LifNeuron::new();
         neuron.integrate(0.5);
+        let after_first = neuron.membrane_potential;
+        let expected_after_second = after_first + 0.5 - (after_first + 0.5) * neuron.decay_rate;
         neuron.integrate(0.5);
-        assert!(neuron.membrane_potential > 0.0);
+        assert!((neuron.membrane_potential - expected_after_second).abs() < 1e-6);
     }
 
     #[test]
@@ -160,12 +161,17 @@ mod tests {
     #[test]
     fn check_fire_at_or_above_threshold_fires_and_hard_resets() {
         let mut neuron = LifNeuron::new();
+
+        neuron.membrane_potential = neuron.threshold;
+        let expected_peak_exact = neuron.membrane_potential;
+        let fired_exact = neuron.check_fire();
+        assert_eq!(fired_exact, Some(expected_peak_exact));
+        assert_eq!(neuron.membrane_potential, 0.0);
+
         neuron.membrane_potential = neuron.threshold + 0.05;
-        let expected_peak = neuron.membrane_potential;
-
-        let fired = neuron.check_fire();
-
-        assert_eq!(fired, Some(expected_peak));
+        let expected_peak_above = neuron.membrane_potential;
+        let fired_above = neuron.check_fire();
+        assert_eq!(fired_above, Some(expected_peak_above));
         assert_eq!(neuron.membrane_potential, 0.0);
     }
 

--- a/src/modulators.rs
+++ b/src/modulators.rs
@@ -329,7 +329,7 @@ mod tests {
         let mut weights = vec![1.0, 1.0];
         let mut thresholds = vec![0.20, 0.20];
         apply_neuromodulation(&mods, &mut weights, &mut thresholds);
-        assert!(weights[0] != 1.0);
+        assert_ne!(weights[0], 1.0);
         assert!(thresholds[0] >= 0.05 && thresholds[0] <= 0.50);
     }
 }

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -44,8 +44,8 @@ pub struct EligibilityTrace {
 
 /// R-STDP hyperparameters.
 pub struct RmStdpConfig {
-    /// Decay time constant, in steps. Typical values are 50-100.
-    pub tau: f32,
+    /// Eligibility trace decay time constant, in steps. Typical values are 50-100.
+    pub tau_eligibility: f32,
     /// Learning rate for converting an eligibility trace into a weight change
     /// when a reward signal arrives. Typical values are 0.01-0.1.
     pub reward_lr: f32,

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -1,47 +1,127 @@
-/// The actual STDP learning rule was missing from the original codebase. Which was orginally too massive for me to manually extract.  So I had AI Agent cdoer break it down from original codebase into smaller pieces. So I am now making the proper changes.
-/// Orginally the algorithm lived in engine.rs.  The orginal codebase had plascticity but this was missing it. So weights were static and never updated in this codebase, disconnected from learning.
-/// The weights don't change immediately instead it records an eligibility trace of memory.  Once a reward signal arrives (dopamine), you convert the eligibility trace into actual weight changes.
-///
-/// R-STDP (Reward based Spike-Timing-Dependent Plasticity) parameters.
-///
-/// ANALOGY: This is the "learning rule" — like Hebb's Rule on a timer.
-/// "Neurons that fire together wire together" but only if the timing is right.
-pub const RM_STDP_TAU_PLUS: f32 = 20.0; // LTP time constant (ms / steps)
-pub const RM_STDP_TAU_MINUS: f32 = 20.0; // LTD time constant (ms / steps)
-pub const RM_STDP_A_PLUS: f32 = 0.01; // Max LTP amplitude
-pub const RM_STDP_A_MINUS: f32 = 0.012; // Max LTD amplitude (slightly stronger → stability)
-pub const RM_STDP_W_MIN: f32 = 0.0; // Minimum weight (no negative / inhibitory yet)
-pub const RM_STDP_W_MAX: f32 = 2.0; // Maximum weight (prevents runaway excitation)
+//! R-STDP (Reward-modulated Spike-Timing-Dependent Plasticity) parameters.
+//!
+//! Weights don't change immediately on a spike pair; instead an eligibility
+//! trace accumulates a "memory" of recent pre/post spike-timing coincidences.
+//! When a reward signal (dopamine) arrives, that trace is converted into an
+//! actual weight change.
+//!
+//! ANALOGY: This is the "learning rule" — like Hebb's Rule on a timer.
+//! "Neurons that fire together wire together," but only if the timing is right.
 
-// Newly added struct to track the state of a single synapse's eligibility trace
+/// LTP (potentiation) time constant, in steps.
+pub const RM_STDP_TAU_PLUS: f32 = 20.0;
+/// LTD (depression) time constant, in steps.
+pub const RM_STDP_TAU_MINUS: f32 = 20.0;
+/// Maximum LTP amplitude.
+pub const RM_STDP_A_PLUS: f32 = 0.01;
+/// Maximum LTD amplitude (slightly stronger than LTP for stability).
+pub const RM_STDP_A_MINUS: f32 = 0.012;
+/// Minimum synaptic weight (no negative/inhibitory weights yet).
+pub const RM_STDP_W_MIN: f32 = 0.0;
+/// Maximum synaptic weight (prevents runaway excitation).
+pub const RM_STDP_W_MAX: f32 = 2.0;
+
+const _: () = assert!(RM_STDP_W_MIN < RM_STDP_W_MAX);
+const _: () = assert!(RM_STDP_A_MINUS >= RM_STDP_A_PLUS);
+
+/// Eligibility trace for a single synapse.
+///
+/// Accumulates based on pre/post spike timing and decays exponentially over
+/// time; positive values favor potentiation (LTP), negative values favor
+/// depression (LTD). Each synapse holds its own trace instance.
 pub struct EligibilityTrace {
-    /// The current value of the eligibility trace, which accumulates based on spike timing
-    pub value: f32, // The value can be positive (LTP) or negative (LTD) depending on the timing of pre/post spikes
-    /// The time constant that determines how quickly the eligibility trace decays
-    pub tau: f32, // tau dictates over how fast it decays, so typical values are 50-100ms/steps
-                  // Each synapse would have its own eligibility trace instance, which gets updated based on pre/post spike timing and decays over time.
+    /// Current trace value.
+    pub value: f32,
+    /// Decay time constant, in steps. Typical values are 50-100.
+    pub tau: f32,
 }
 
-// Holds Rm-STDP hyperparameters
+/// R-STDP hyperparameters.
 pub struct RmStdpConfig {
-    /// Eligibility trace decay time constant (ms / steps)
-    pub tau_eligibility: f32, // Determines how long the eligibility trace lasts before it decays back to zero. Typical values are 50-100ms/steps.
-    /// LTP time constant (ms / steps)
-    pub reward_lr: f32, // This dicates the learning rate for converting the eligibility trace into actual weight changes when a reward signal arrives. Typical values are 0.01-0.1.
-    /// Weight clipping bounds
-    pub w_min: f32, // Plays a role in preventing runaway excitation or complete silencing. Typical values are 0.0 (no negative weights) to 1.0 or 2.0 (allowing some potentiation).
-    // Minimum weight (no negative / inhibitory yet)
-    pub w_max: f32, // Maximum weight (prevents runaway excitation)
+    /// Eligibility trace decay time constant, in steps. Typical values are 50-100.
+    pub tau_eligibility: f32,
+    /// Learning rate for converting an eligibility trace into a weight change
+    /// when a reward signal arrives. Typical values are 0.01-0.1.
+    pub reward_lr: f32,
+    /// Minimum weight (no negative/inhibitory weights yet).
+    pub w_min: f32,
+    /// Maximum weight (prevents runaway excitation).
+    pub w_max: f32,
 }
 
-// Makes the trace decay each step on 'EligibilityTrace' struct
 impl EligibilityTrace {
-    // Call this method each time step to decay the eligibility trace
+    /// Decay the trace by one step.
     pub fn decay(&mut self) {
-        // Guard against non-positive tau which would cause division by zero or
-        // exponential growth instead of decay.
+        // Guard against non-positive tau, which would cause division by zero
+        // or exponential growth instead of decay.
         let tau = self.tau.max(f32::EPSILON);
-        // Exponential decay of the eligibility trace over time
-        self.value *= (-1.0 / tau).exp(); // Exponential decay based on tau
+        self.value *= (-1.0 / tau).exp();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decay_scales_value_by_exp_neg_inv_tau() {
+        let mut trace = EligibilityTrace {
+            value: 1.0,
+            tau: 50.0,
+        };
+        let expected_factor = (-1.0_f32 / 50.0).exp();
+
+        trace.decay();
+
+        assert!((trace.value - expected_factor).abs() < 1e-6);
+    }
+
+    #[test]
+    fn decay_applied_repeatedly_compounds_toward_zero() {
+        let mut trace = EligibilityTrace {
+            value: 1.0,
+            tau: 50.0,
+        };
+        let factor = (-1.0_f32 / 50.0).exp();
+
+        for _ in 0..5 {
+            trace.decay();
+        }
+
+        let expected = factor.powi(5);
+        assert!((trace.value - expected).abs() < 1e-5);
+        assert!(trace.value < 1.0);
+    }
+
+    #[test]
+    fn decay_preserves_sign_for_negative_values() {
+        let mut trace = EligibilityTrace {
+            value: -1.0,
+            tau: 50.0,
+        };
+        trace.decay();
+        assert!(trace.value < 0.0);
+    }
+
+    #[test]
+    fn decay_with_zero_tau_does_not_panic_or_diverge() {
+        let mut trace = EligibilityTrace {
+            value: 1.0,
+            tau: 0.0,
+        };
+        trace.decay();
+        assert!(trace.value.is_finite());
+        assert!(trace.value >= 0.0);
+    }
+
+    #[test]
+    fn decay_with_negative_tau_does_not_panic_or_diverge() {
+        let mut trace = EligibilityTrace {
+            value: 1.0,
+            tau: -10.0,
+        };
+        trace.decay();
+        assert!(trace.value.is_finite());
+        assert!(trace.value >= 0.0);
     }
 }

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -1,12 +1,18 @@
 //! R-STDP (Reward-modulated Spike-Timing-Dependent Plasticity) parameters.
 //!
-//! Weights don't change immediately on a spike pair; instead an eligibility
-//! trace accumulates a "memory" of recent pre/post spike-timing coincidences.
-//! When a reward signal (dopamine) arrives, that trace is converted into an
-//! actual weight change.
+//! This module holds R-STDP constants, `RmStdpConfig`, and a standalone
+//! [`EligibilityTrace`] building block for future or external use.
 //!
-//! ANALOGY: This is the "learning rule" — like Hebb's Rule on a timer.
-//! "Neurons that fire together wire together," but only if the timing is right.
+//! **Live engine path:** `SpikingNetwork::apply_stdp` in `src/engine.rs` is
+//! dopamine-gated and updates weights directly from spike timing. It does
+//! **not** currently consume or convert `EligibilityTrace` values.
+//!
+//! Idealized R-STDP (not yet wired in-engine): an eligibility trace accumulates
+//! a "memory" of recent pre/post spike-timing coincidences, then a reward
+//! signal (dopamine) converts that trace into a weight change.
+//!
+//! ANALOGY: Hebb's Rule on a timer — "neurons that fire together wire
+//! together," but only if the timing (and, eventually, reward) is right.
 
 /// LTP (potentiation) time constant, in steps.
 pub const RM_STDP_TAU_PLUS: f32 = 20.0;

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -1,7 +1,7 @@
 //! R-STDP (Reward-modulated Spike-Timing-Dependent Plasticity) parameters.
 //!
 //! This module holds R-STDP constants, `RmStdpConfig`, and a standalone
-//! [`EligibilityTrace`] building block for future or external use.
+//! [`EligibilityTrace`] building block for standalone use.
 //!
 //! **Live engine path:** `SpikingNetwork::apply_stdp` in `src/engine.rs` is
 //! dopamine-gated and updates weights directly from spike timing. It does
@@ -44,8 +44,8 @@ pub struct EligibilityTrace {
 
 /// R-STDP hyperparameters.
 pub struct RmStdpConfig {
-    /// Eligibility trace decay time constant, in steps. Typical values are 50-100.
-    pub tau_eligibility: f32,
+    /// Decay time constant, in steps. Typical values are 50-100.
+    pub tau: f32,
     /// Learning rate for converting an eligibility trace into a weight change
     /// when a reward signal arrives. Typical values are 0.01-0.1.
     pub reward_lr: f32,
@@ -56,7 +56,7 @@ pub struct RmStdpConfig {
 }
 
 impl EligibilityTrace {
-    /// Decay the trace by one step.
+    /// Decay the trace by one step (assumes dt = 1 unit).
     pub fn decay(&mut self) {
         // Guard against non-positive tau, which would cause division by zero
         // or exponential growth instead of decay.


### PR DESCRIPTION
## Summary

- Criterion bench docs/tests and `rm_stdp` cleanup; explicit `[profile.bench]` inherits `release`
- Sentry example: `SENTRY_ENVIRONMENT` (default `development`), no info-level probe noise
- Drop unused direct `serde_json`; crates.io metadata/`rust-version`/dev+release-with-debug profiles
- `REVIEW.md` local Qodana gate + accepted noise notes; CHANGELOG under `[Unreleased]`
- Version stays **0.5.0** (crates.io still at 0.4.0; first post-0.4 publish, not 0.5.1)

## Local Gate 0 (before push)

| Check | Result |
|-------|--------|
| `cargo fmt --check` | pass |
| `clippy --all-targets --all-features -D warnings` | pass |
| `cargo test --all-features` | 62 unit + 16 sentry + 1 doctest |
| `cargo build --release --all-features` | pass |
| `cargo build --profile release-with-debug` | pass |
| `cargo bench --no-run` + `neuron_bench --quick` | Criterion runs (`harness = false`) |
| examples (dev + release) | pass |
| `cargo publish --dry-run` | packages 56 files, dry-run upload aborted OK |
| domain hygiene `cargo doc` | pass |
| local `qodana scan` (qodana-rust) | see notes below |

### Qodana notes

- Real fixes applied: unused `serde_json`, `assert_ne!` nit
- **Accepted baseline:** `DuplicatedCode` in RK4 stages (FHN/HH) — intentional
- **Authoritative for Rust correctness:** host `cargo check` / clippy (Docker linter may emit `RsBorrowChecker` false positives when Cargo project load is flaky on pinned 1.97.1)

## Test plan

- [x] Full REVIEW gate locally
- [x] `cargo publish --dry-run`
- [x] Local Qodana (actionable items addressed; noise documented)
- [ ] CI green on this PR (incl. remote Qodana)
- [ ] After merge: cut CHANGELOG into dated 0.5.0, `cargo publish`, tag `v0.5.0`