### PR TITLE
docs: rustdoc textbook spine + MSRV policy (#89 #79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
           toolchain: 1.97.1
           components: clippy, rustfmt
 
+      # Keep Cargo.toml rust-version, rust-toolchain.toml, and this job's
+      # toolchain: string identical (MSRV single source of truth — #79).
+      - name: Verify MSRV pins agree
+        run: |
+          set -euo pipefail
+          cargo_rv=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          toolchain_ch=$(grep -m1 '^channel' rust-toolchain.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          ci_rv='1.97.1'
+          echo "Cargo.toml rust-version=$cargo_rv"
+          echo "rust-toolchain.toml channel=$toolchain_ch"
+          echo "ci.yml pin=$ci_rv"
+          test "$cargo_rv" = "$toolchain_ch"
+          test "$cargo_rv" = "$ci_rv"
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,25 @@ jobs:
 
       # Keep Cargo.toml rust-version, rust-toolchain.toml, and this job's
       # toolchain: string identical (MSRV single source of truth — #79).
+      # ci_rv is parsed from the dtolnay/rust-toolchain `toolchain:` input above
+      # so a bump of only that pin cannot silently pass this check.
       - name: Verify MSRV pins agree
         run: |
           set -euo pipefail
           cargo_rv=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
           toolchain_ch=$(grep -m1 '^channel' rust-toolchain.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          ci_rv='1.97.1'
+          # Extract from the Install Rust step's `toolchain:` input (not a hardcoded mirror).
+          ci_rv=$(awk '
+            /uses: dtolnay\/rust-toolchain@/ { in_rt = 1; next }
+            in_rt && /^[[:space:]]*toolchain:[[:space:]]*/ {
+              sub(/^[[:space:]]*toolchain:[[:space:]]*/, "")
+              sub(/[[:space:]]*$/, "")
+              print
+              exit
+            }
+            in_rt && /^[[:space:]]*- name:/ { exit }
+          ' .github/workflows/ci.yml)
+          test -n "$ci_rv"
           echo "Cargo.toml rust-version=$cargo_rv"
           echo "rust-toolchain.toml channel=$toolchain_ch"
           echo "ci.yml pin=$ci_rv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - Stop tracking `.cubic/wiki` in git; ignore `.cubic/` and exclude it from the crates.io package so regenerated cubic wiki is not a documentation source of truth (#90).
+- **Rustdoc textbook spine:** crate-root syllabus, module docs for `engine` / `lif` / `izhikevich` / `modulators`, and expanded `SpikingNetwork::step` contract (pipeline order, STDP honesty, doctest) (#89).
+- **MSRV policy:** README Requirements + crate docs state Rust **1.97.1**; CI verifies `Cargo.toml` / `rust-toolchain.toml` / workflow pin stay identical (#79).
 
 ## [0.5.1] - 2026-08-08
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ These types ship in the crate for research and composition, but are **not** wire
 
 Use them directly; use `HebbianIzhikevichNetwork` for a small classical-STDP Izhikevich helper separate from `SpikingNetwork`.
 
+## Requirements
+
+| | |
+|--|--|
+| **MSRV** | **Rust 1.97.1** (`rust-version` in `Cargo.toml`) |
+| **Edition** | 2024 |
+| **Pin** | [`rust-toolchain.toml`](rust-toolchain.toml) (channel `1.97.1`) |
+
+CI installs the same toolchain. Keep `Cargo.toml` `rust-version`, `rust-toolchain.toml`, and the version string in `.github/workflows/ci.yml` identical (the CI job fails if they drift).
+
 ## Installation
 
 ```toml

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -8,6 +8,10 @@ Run these commands before claiming a PR is ready, especially when touching `src/
 - After resolving merges with `main`
 - Before requesting review or merge
 
+## MSRV pin rule
+
+`Cargo.toml` `rust-version`, `rust-toolchain.toml` `channel`, and the toolchain string in `.github/workflows/ci.yml` must stay **identical**. CI enforces this; do not bump one without the others.
+
 ## Mandatory commands
 
 ```bash

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -100,7 +100,9 @@ impl SpikingNetwork {
     /// 2. Recompute LIF targets from neuromodulators: assign `decay_rate`
     ///    directly; soft-update `threshold` toward its target (learning-rate blend).
     /// 3. Update per-channel predictive EMA and surprise (`pred_errors`).
-    /// 4. Stochastically stamp `input_spike_times` (Poisson-style from |stimuli|).
+    /// 4. For each channel with `|stimuli| > 0.01`, run a Bernoulli trial
+    ///    with probability `clamp(|stimuli|, 0.0, 1.0)` and stamp
+    ///    `input_spike_times` on success.
     /// 5. Integrate each LIF neuron (weighted stimuli + surprise), then `check_fire`.
     /// 6. Lateral inhibition on non-firing LIF cells if anyone spiked.
     /// 7. Dopamine-gated STDP on LIF weights (`apply_stdp`); skipped if learning

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,3 +1,22 @@
+//! # Engine — LIF + Izhikevich `SpikingNetwork`
+//!
+//! Topology-neutral simulation core. One network owns:
+//!
+//! - a **LIF** bank (`neurons`) driven by multi-channel stimuli and STDP,
+//! - an **Izhikevich** bank (`iz_neurons`) driven from mean LIF membrane potential
+//!   + dopamine (not a second full STDP pipeline),
+//! - a [`NeuroModulators`] snapshot updated each step.
+//!
+//! Construction is blank weights / no domain topology:
+//! [`SpikingNetwork::new`] (16 / 5 / 16) or [`SpikingNetwork::with_dimensions`].
+//!
+//! For classical Hebbian STDP on a small Izhikevich network, see
+//! [`crate::hebbian`] — that path is separate from this engine.
+//!
+//! Plasticity honesty: live reward-modulated updates run inside `step` via
+//! `apply_stdp` (dopamine-gated). [`crate::EligibilityTrace`] is a building
+//! block and is **not** consumed by the engine yet (see [`crate::rm_stdp`]).
+
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
@@ -9,12 +28,17 @@ use super::rm_stdp::*;
 /// L1 synaptic weight budget per neuron (total weight sum target).
 const WEIGHT_BUDGET: f32 = 2.0;
 
+/// Errors from [`SpikingNetwork::step`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StepError {
+    /// `stimuli.len()` did not match the network's `num_channels`.
     InputLenMismatch { expected: usize, got: usize },
 }
 
-/// Core network type integrating LIF and Izhikevich neurons.
+/// Topology-neutral network: LIF bank + Izhikevich bank + neuromodulators.
+///
+/// Only these two neuron types are wired here. Other models in the crate are
+/// standalone (see crate root docs).
 #[derive(Serialize, Deserialize)]
 pub struct SpikingNetwork {
     /// Bank 1: LIF neurons.
@@ -61,7 +85,45 @@ impl SpikingNetwork {
         }
     }
 
-    /// Step the network with input stimuli and modulators.
+    /// Advance the network by one discrete time step.
+    ///
+    /// # Contract
+    ///
+    /// - `stimuli.len()` must equal [`Self::num_channels`], else
+    ///   [`StepError::InputLenMismatch`].
+    /// - Returns the indices of **LIF** neurons that fired this step (Izhikevich
+    ///   spikes are not listed in the return value).
+    ///
+    /// # Order of work
+    ///
+    /// 1. Store `modulators` and derive stress / learning rates.
+    /// 2. Soft-update LIF `decay_rate` and `threshold` from neuromodulators.
+    /// 3. Update per-channel predictive EMA and surprise (`pred_errors`).
+    /// 4. Stochastically stamp `input_spike_times` (Poisson-style from |stimuli|).
+    /// 5. Integrate each LIF neuron (weighted stimuli + surprise), then `check_fire`.
+    /// 6. Lateral inhibition on non-firing LIF cells if anyone spiked.
+    /// 7. Dopamine-gated STDP on LIF weights (`apply_stdp`); skipped if learning
+    ///    rate ≈ 0. Weights are **not** updated via [`crate::EligibilityTrace`].
+    /// 8. Renormalize LIF weights to an L1 budget and clamp to R-STDP bounds.
+    /// 9. Drive each Izhikevich neuron from mean LIF membrane potential + dopamine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neuromod::{NeuroModulators, SpikingNetwork, StepError};
+    ///
+    /// let mut net = SpikingNetwork::with_dimensions(8, 2, 4);
+    /// let modulators = NeuroModulators::default();
+    ///
+    /// // Wrong length → structured error
+    /// assert!(matches!(
+    ///     net.step(&[0.1, 0.2], &modulators),
+    ///     Err(StepError::InputLenMismatch { expected: 4, got: 2 })
+    /// ));
+    ///
+    /// let spikes = net.step(&[0.5; 4], &modulators).expect("length matches");
+    /// assert!(spikes.iter().all(|&i| i < 8));
+    /// ```
     pub fn step(
         &mut self,
         stimuli: &[f32],

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -97,7 +97,8 @@ impl SpikingNetwork {
     /// # Order of work
     ///
     /// 1. Store `modulators` and derive stress / learning rates.
-    /// 2. Soft-update LIF `decay_rate` and `threshold` from neuromodulators.
+    /// 2. Recompute LIF targets from neuromodulators: assign `decay_rate`
+    ///    directly; soft-update `threshold` toward its target (learning-rate blend).
     /// 3. Update per-channel predictive EMA and surprise (`pred_errors`).
     /// 4. Stochastically stamp `input_spike_times` (Poisson-style from |stimuli|).
     /// 5. Integrate each LIF neuron (weighted stimuli + surprise), then `check_fire`.

--- a/src/izhikevich.rs
+++ b/src/izhikevich.rs
@@ -1,3 +1,13 @@
+//! # Izhikevich neurons
+//!
+//! Secondary bank of [`crate::SpikingNetwork`]. Each tick the engine computes a
+//! scalar drive from **mean LIF membrane potential** and **dopamine**, then
+//! calls [`IzhikevichNeuron::step`] on every unit. This path does **not** run
+//! the LIF STDP / multi-channel weight machinery.
+//!
+//! For classical (unmodulated) Hebbian STDP among Izhikevich cells, use
+//! [`crate::hebbian`] (`HebbianIzhikevichNetwork`) — separate from the engine.
+
 use serde::{Deserialize, Serialize};
 
 /// Biologically plausible neuron model by Eugene M. Izhikevich (2003).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,26 @@
 //! [`SpikingNetwork`] engine (LIF + Izhikevich banks), generic neuromodulators,
 //! classical STDP helpers, and reward-modulated STDP types.
 //!
+//! Aimed at **SNN / neuroscience readers learning Rust**: equations and
+//! engine contracts first; idiomatic APIs second.
+//!
+//! ## Requirements
+//!
+//! - **Rust 1.97.1+** (MSRV; also `rust-version` in `Cargo.toml` and
+//!   [`rust-toolchain.toml`](https://github.com/Limen-Neural/neuromod/blob/main/rust-toolchain.toml)).
+//! - Edition **2024**.
+//!
+//! ## Syllabus (reading order on docs.rs)
+//!
+//! 1. This page — engine vs standalone honesty and a quick start.
+//! 2. [`engine`] — [`SpikingNetwork`] and the per-tick [`SpikingNetwork::step`] contract.
+//! 3. [`lif`] / [`izhikevich`] — the two banks the engine actually wires.
+//! 4. [`modulators`] — dopamine / serotonin / acetylcholine / norepinephrine.
+//! 5. [`rm_stdp`] / [`hebbian`] — plasticity building blocks (eligibility traces are
+//!    **not** yet consumed by the live engine path; see those modules).
+//! 6. Standalone models ([`lapicque`], [`gif`], [`fitzhugh_nagumo`], [`hodgkin_huxley`])
+//!    for research use outside the engine.
+//!
 //! ## Engine vs standalone models
 //!
 //! - **`SpikingNetwork`** wires **LIF** and **Izhikevich** neuron banks only
@@ -12,8 +32,8 @@
 //!   `HodgkinHuxleyNeuron`, …) are usable on their own; they are not alternate
 //!   engine banks.
 //! - Plasticity: classical Hebbian STDP utilities plus `EligibilityTrace` /
-//!   `RmStdpConfig` building blocks (see crate docs and examples for current
-//!   integration status).
+//!   `RmStdpConfig` building blocks. Live `step` learning is dopamine-gated and
+//!   updates LIF weights **directly** (not via eligibility conversion).
 //!
 //! ## Features
 //!

--- a/src/lif.rs
+++ b/src/lif.rs
@@ -1,3 +1,18 @@
+//! # Leaky integrate-and-fire (LIF) neurons
+//!
+//! Primary bank of [`crate::SpikingNetwork`]: each [`LifNeuron`] has a membrane
+//! potential, threshold, decay, and a vector of synaptic weights (one per input
+//! channel). The engine integrates, fires, applies lateral inhibition, and
+//! runs dopamine-gated STDP on these weights.
+//!
+//! [`PoissonEncoder`] is a small helper that turns a scalar intensity into a
+//! binary spike train (Bernoulli trials). It is **not** required by
+//! `SpikingNetwork::step` (the engine encodes stimuli itself), but is useful in
+//! demos and tests.
+//!
+//! For the classical Lapicque root model, see [`crate::lapicque`]. For the
+//! secondary engine bank, see [`crate::izhikevich`].
+
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 

--- a/src/modulators.rs
+++ b/src/modulators.rs
@@ -1,3 +1,16 @@
+//! # Neuromodulators and domain-agnostic reward hooks
+//!
+//! Four scalar modulators (dopamine, serotonin, acetylcholine, norepinephrine)
+//! with exponential decay and helpers. [`NeuroModulators`] is the snapshot
+//! passed into [`crate::SpikingNetwork::step`] each tick.
+//!
+//! [`SignalProfile`] maps unitless external signals into those levels.
+//! [`GenericReward`] / [`UnitReward`] let downstream crates shape rewards without
+//! hard-coding domain logic in this crate.
+//!
+//! [`apply_neuromodulation`] tweaks weight/threshold slices without owning a
+//! full network — useful for tests and simple pipelines.
+
 use serde::{Deserialize, Serialize};
 
 const DOPAMINE_DECAY: f32 = 0.95;


### PR DESCRIPTION
## **User description**

## Summary

Limen-Neural/neuromod#89 **— rustdoc spine (living textbook, Approach 1)**

* Crate-root syllabus + Requirements (MSRV)
* Module `//!` for `engine`, `lif`, `izhikevich`, `modulators`
* Deep `SpikingNetwork::step` docs: order of work, STDP honesty, doctest

Limen-Neural/neuromod#79 **— consumer-facing MSRV**

* README **Requirements** section
* CI step: `Cargo.toml` / `rust-toolchain.toml` / ci.yml pin must match
* REVIEW.md pin rule

Closes Limen-Neural/neuromod#89  <br>Closes Limen-Neural/neuromod#79

## Test plan

- [X] `cargo test --all-features` (63 unit + 2 doctests)
- [X] `cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cargo doc --no-deps` clean
- [X] MSRV pin agreement check

## Summary by cubic

Adds a rustdoc “textbook spine” across the crate and documents the engine contract, and sets a consumer-facing MSRV of Rust 1.97.1 with CI enforcing pin agreement.

* **New Features**
  * Crate-root syllabus and module docs for `engine`, `lif`, `izhikevich`, and `modulators`.
  * Expanded `SpikingNetwork::step` docs: input contract, processing order, dopamine‑gated STDP, and a doctest.
  * Consumer-facing MSRV: Rust 1.97.1 documented in README and crate docs; CI checks `Cargo.toml` `rust-version`, `rust-toolchain.toml` `channel`, and `.github/workflows/ci.yml` stay identical.
* **Migration**
  * Build with Rust 1.97.1. If bumping MSRV, update `Cargo.toml`, `rust-toolchain.toml`, and the workflow pin together or CI will fail.

Written for commit ef7e24922d86728b69ffe6d65263ab5c065d1497. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

---

## **CodeAnt-AI Description**

Document the network behavior and enforce a consistent Rust support policy

### What Changed

* Added a crate and module reading guide explaining the network’s LIF and Izhikevich banks, neuromodulators, standalone models, and learning behavior
* Documented the per-step processing order, input requirements, returned LIF spikes, and how dopamine-gated learning updates weights
* Published Rust 1.97.1 and Edition 2024 as project requirements in the README and crate documentation
* CI now fails when the Rust version differs between project metadata, the toolchain file, and the workflow

### Impact

`✅ Clearer network behavior and learning expectations`  <br>`✅ Easier onboarding through a documented reading path`  <br>`✅ Fewer build failures from inconsistent Rust versions`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>