### PR TITLE
chore: release neuromod 0.5.2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 # Codecov coverage workflow (separate from main CI per observability split).
 # Third-party Actions are pinned to immutable commit SHAs (Aikido supply-chain policy).
+#
+# Badge shows "unknown" until Codecov has an activated repo + successful upload.
+# Activate Limen-Neural/neuromod at https://app.codecov.io/gh/Limen-Neural/neuromod
+# and set repo secret CODECOV_TOKEN to the Codecov upload token for that repo.
 name: Codecov
 
 on:
@@ -52,14 +56,18 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          files: junit.xml
+          # Fail loudly — silent 404s left the README badge on "unknown".
+          fail_ci_if_error: true
 
-      - name: Codecov
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
+          disable_search: true
           slug: Limen-Neural/neuromod
-          fail_ci_if_error: false
+          # Surface upload failures (e.g. inactive repo / wrong token).
+          fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,8 @@
 # Codecov coverage workflow (separate from main CI per observability split).
 # Third-party Actions are pinned to immutable commit SHAs (Aikido supply-chain policy).
 #
-# Limen-Neural Codecov org allows tokenless uploads (no upload token required).
-# Do not pass a stale CODECOV_TOKEN — wrong tokens return "Repository not found"
-# and leave the README badge on "unknown". Optional: set CODECOV_TOKEN only if you
-# re-enable required tokens in Codecov global upload settings.
+# Codecov requires CODECOV_TOKEN for this org (tokenless returns HTTP 400).
+# Pass secrets.CODECOV_TOKEN; uploads are non-blocking (fail_ci_if_error: false).
 name: Codecov
 
 on:
@@ -57,9 +55,10 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           files: junit.xml
-          # Tokenless: org setting allows uploads without a token.
-          # Only pass secrets.CODECOV_TOKEN if required tokens are re-enabled.
-          fail_ci_if_error: true
+          # Codecov no longer accepts tokenless uploads for this org (HTTP 400).
+          # Prefer secrets.CODECOV_TOKEN; do not fail the job if upload is unavailable.
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
@@ -68,5 +67,7 @@ jobs:
           files: lcov.info
           disable_search: true
           slug: Limen-Neural/neuromod
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Upload is observability, not a release gate; tokenless is broken.
+          fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: checkout + upload only (no contents write).
+permissions:
+  contents: read
+
 jobs:
   codecov:
     name: Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,10 @@
 # Codecov coverage workflow (separate from main CI per observability split).
 # Third-party Actions are pinned to immutable commit SHAs (Aikido supply-chain policy).
 #
-# Badge shows "unknown" until Codecov has an activated repo + successful upload.
-# Activate Limen-Neural/neuromod at https://app.codecov.io/gh/Limen-Neural/neuromod
-# and set repo secret CODECOV_TOKEN to the Codecov upload token for that repo.
+# Limen-Neural Codecov org allows tokenless uploads (no upload token required).
+# Do not pass a stale CODECOV_TOKEN — wrong tokens return "Repository not found"
+# and leave the README badge on "unknown". Optional: set CODECOV_TOKEN only if you
+# re-enable required tokens in Codecov global upload settings.
 name: Codecov
 
 on:
@@ -55,19 +56,17 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
-          # Fail loudly — silent 404s left the README badge on "unknown".
+          # Tokenless: org setting allows uploads without a token.
+          # Only pass secrets.CODECOV_TOKEN if required tokens are re-enabled.
           fail_ci_if_error: true
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           disable_search: true
           slug: Limen-Neural/neuromod
-          # Surface upload failures (e.g. inactive repo / wrong token).
           fail_ci_if_error: true
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs, CI, and packaging hygiene for the v0.5.2 milestone. Publish with `cargo pu
 - **MSRV policy:** README Requirements + crate docs state Rust **1.97.1**; CI verifies `Cargo.toml` / `rust-toolchain.toml` / workflow pin stay identical (#79).
 - **CI OS matrix:** GitHub Actions core CI runs build/clippy/tests on Linux, macOS, and Windows (`ubuntu-latest`, `macos-latest`, `windows-latest`); README Requirements and CI section document the three-platform matrix and the `paths-filter` gate for nextest/cargo-hack (#94, #95).
 - Domain-agnostic docs check builds with `cargo doc --all-features --no-deps` before the forbidden-term scan.
-- **Codecov:** coverage/test-result uploads fail the job on error (no silent “unknown” badge); README documents repo activation + `CODECOV_TOKEN` for `Limen-Neural/neuromod`.
+- **Codecov:** tokenless uploads (org no longer requires upload tokens); official badge markdown with graph token; uploads fail the job on error so a stale secret cannot hide a broken badge.
 
 ## [0.5.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs, CI, and packaging hygiene for the v0.5.2 milestone. Publish with `cargo pu
 - **MSRV policy:** README Requirements + crate docs state Rust **1.97.1**; CI verifies `Cargo.toml` / `rust-toolchain.toml` / workflow pin stay identical (#79).
 - **CI OS matrix:** GitHub Actions core CI runs build/clippy/tests on Linux, macOS, and Windows (`ubuntu-latest`, `macos-latest`, `windows-latest`); README Requirements and CI section document the three-platform matrix and the `paths-filter` gate for nextest/cargo-hack (#94, #95).
 - Domain-agnostic docs check builds with `cargo doc --all-features --no-deps` before the forbidden-term scan.
+- **Codecov:** coverage/test-result uploads fail the job on error (no silent “unknown” badge); README documents repo activation + `CODECOV_TOKEN` for `Limen-Neural/neuromod`.
 
 ## [0.5.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs, CI, and packaging hygiene for the v0.5.2 milestone. Publish with `cargo pu
 - **MSRV policy:** README Requirements + crate docs state Rust **1.97.1**; CI verifies `Cargo.toml` / `rust-toolchain.toml` / workflow pin stay identical (#79).
 - **CI OS matrix:** GitHub Actions core CI runs build/clippy/tests on Linux, macOS, and Windows (`ubuntu-latest`, `macos-latest`, `windows-latest`); README Requirements and CI section document the three-platform matrix and the `paths-filter` gate for nextest/cargo-hack (#94, #95).
 - Domain-agnostic docs check builds with `cargo doc --all-features --no-deps` before the forbidden-term scan.
-- **Codecov:** tokenless uploads (org no longer requires upload tokens); official badge markdown with graph token; uploads fail the job on error so a stale secret cannot hide a broken badge.
+- **Codecov:** official badge markdown with graph token; CI uploads via `CODECOV_TOKEN` (tokenless returns HTTP 400 for this org); upload steps use `fail_ci_if_error: false` so coverage remains non-blocking; coverage workflow declares `permissions: contents: read`.
 
 ## [0.5.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-12
+
+Docs, CI, and packaging hygiene for the v0.5.2 milestone. Publish with `cargo publish` after this tag lands.
+
 ### Removed
 
 - Optional `sentry` Cargo feature, `examples/sentry.rs`, `tests/sentry_integration.rs`, and `.github/workflows/sentry-release.yml`. Observability belongs in application binaries (depend on `sentry` there); the library no longer pulls or demos Sentry (#88, #78).
@@ -13,7 +17,8 @@ All notable changes to this project are documented in this file.
 - Stop tracking `.cubic/wiki` in git; ignore `.cubic/` and exclude it from the crates.io package so regenerated cubic wiki is not a documentation source of truth (#90).
 - **Rustdoc textbook spine:** crate-root syllabus, module docs for `engine` / `lif` / `izhikevich` / `modulators`, and expanded `SpikingNetwork::step` contract (pipeline order, STDP honesty, doctest) (#89).
 - **MSRV policy:** README Requirements + crate docs state Rust **1.97.1**; CI verifies `Cargo.toml` / `rust-toolchain.toml` / workflow pin stay identical (#79).
-- **CI OS matrix:** GitHub Actions core CI runs build/clippy/tests on Linux, macOS, and Windows; README Requirements and CI section document the three-platform matrix (#94).
+- **CI OS matrix:** GitHub Actions core CI runs build/clippy/tests on Linux, macOS, and Windows (`ubuntu-latest`, `macos-latest`, `windows-latest`); README Requirements and CI section document the three-platform matrix and the `paths-filter` gate for nextest/cargo-hack (#94, #95).
+- Domain-agnostic docs check builds with `cargo doc --all-features --no-deps` before the forbidden-term scan.
 
 ## [0.5.1] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neuromod"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neuromod"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/neuromod.svg)](https://crates.io/crates/neuromod)
 [![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod)
 [![License](https://img.shields.io/crates/l/neuromod.svg)](https://github.com/Limen-Neural/neuromod#license)
-[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg)](https://app.codecov.io/gh/Limen-Neural/neuromod)
+[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg?token=V0U0K5P6PW)](https://codecov.io/gh/Limen-Neural/neuromod)
 
 Biologically grounded spiking neural network (SNN) primitives in Rust: a topology-neutral `SpikingNetwork` engine, generic neuromodulators, STDP building blocks, and standalone neuron models.
 
@@ -203,17 +203,13 @@ cargo hack check --feature-powerset --exclude-no-default-features --keep-going
 
 ### Codecov
 
-[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg)](https://app.codecov.io/gh/Limen-Neural/neuromod)
+[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg?token=V0U0K5P6PW)](https://codecov.io/gh/Limen-Neural/neuromod)
 
 - Configuration: [`codecov.yml`](codecov.yml)
 - Workflow: [`.github/workflows/coverage.yml`](.github/workflows/coverage.yml)
-- Dashboard: [app.codecov.io/gh/Limen-Neural/neuromod](https://app.codecov.io/gh/Limen-Neural/neuromod)
+- Dashboard: [codecov.io/gh/Limen-Neural/neuromod](https://codecov.io/gh/Limen-Neural/neuromod)
 
-**Why the badge can show `unknown`:** Codecov has no coverage totals until the repo is **activated** under the `Limen-Neural` org and CI uploads succeed. Recent uploads returned `Repository not found` while the job still “passed” because failures were ignored. Fix:
-
-1. Open [Codecov → Limen-Neural/neuromod](https://app.codecov.io/gh/Limen-Neural/neuromod) and activate the repo (GitHub App install for the org if prompted).
-2. Copy the **repository upload token** into the GitHub Actions secret `CODECOV_TOKEN` for this repo (Settings → Secrets and variables → Actions).
-3. Re-run the **Codecov** workflow on `main` (or merge a PR). Uploads now fail the job if Codecov rejects them (`fail_ci_if_error: true`).
+The badge uses Codecov’s graph token (from **Configuration → Badges & Graphs**). The Limen-Neural Codecov org allows **tokenless uploads**, so CI does not send `CODECOV_TOKEN` (a stale org upload token was causing `Repository not found` and left the badge on `unknown`). After a green **Codecov** job on `main`, the badge shows a coverage %.
 
 Local coverage (also listed under [Development](#development)):
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,12 @@ cargo hack check --feature-powerset --exclude-no-default-features --keep-going
 - Workflow: [`.github/workflows/coverage.yml`](.github/workflows/coverage.yml)
 - Dashboard: [codecov.io/gh/Limen-Neural/neuromod](https://codecov.io/gh/Limen-Neural/neuromod)
 
-The badge uses Codecov’s graph token (from **Configuration → Badges & Graphs**). The Limen-Neural Codecov org allows **tokenless uploads**, so CI does not send `CODECOV_TOKEN` (a stale org upload token was causing `Repository not found` and left the badge on `unknown`). After a green **Codecov** job on `main`, the badge shows a coverage %.
+The badge uses Codecov’s graph token (from **Configuration → Badges & Graphs**).
+**Uploads** need the repository secret **`CODECOV_TOKEN`** (tokenless uploads return
+HTTP 400 for this org). The coverage workflow passes that token and sets
+`fail_ci_if_error: false`, so a missing/stale token does **not** fail CI—only the
+badge may stay `unknown` until the secret is correct. After a successful upload on
+`main`, the badge shows a coverage %.
 
 Local coverage (also listed under [Development](#development)):
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/neuromod.svg)](https://crates.io/crates/neuromod)
 [![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod)
 [![License](https://img.shields.io/crates/l/neuromod.svg)](https://github.com/Limen-Neural/neuromod#license)
-[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/branch/main/graph/badge.svg)](https://codecov.io/gh/Limen-Neural/neuromod)
+[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg)](https://app.codecov.io/gh/Limen-Neural/neuromod)
 
 Biologically grounded spiking neural network (SNN) primitives in Rust: a topology-neutral `SpikingNetwork` engine, generic neuromodulators, STDP building blocks, and standalone neuron models.
 
@@ -203,10 +203,17 @@ cargo hack check --feature-powerset --exclude-no-default-features --keep-going
 
 ### Codecov
 
-[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/branch/main/graph/badge.svg)](https://codecov.io/gh/Limen-Neural/neuromod)
+[![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg)](https://app.codecov.io/gh/Limen-Neural/neuromod)
 
 - Configuration: [`codecov.yml`](codecov.yml)
 - Workflow: [`.github/workflows/coverage.yml`](.github/workflows/coverage.yml)
+- Dashboard: [app.codecov.io/gh/Limen-Neural/neuromod](https://app.codecov.io/gh/Limen-Neural/neuromod)
+
+**Why the badge can show `unknown`:** Codecov has no coverage totals until the repo is **activated** under the `Limen-Neural` org and CI uploads succeed. Recent uploads returned `Repository not found` while the job still “passed” because failures were ignored. Fix:
+
+1. Open [Codecov → Limen-Neural/neuromod](https://app.codecov.io/gh/Limen-Neural/neuromod) and activate the repo (GitHub App install for the org if prompted).
+2. Copy the **repository upload token** into the GitHub Actions secret `CODECOV_TOKEN` for this repo (Settings → Secrets and variables → Actions).
+3. Re-run the **Codecov** workflow on `main` (or merge a PR). Uploads now fail the job if Codecov rejects them (`fail_ci_if_error: true`).
 
 Local coverage (also listed under [Development](#development)):
 
@@ -216,7 +223,6 @@ cargo llvm-cov --all-features --lcov --output-path lcov.info
 # HTML report: cargo llvm-cov --all-features --html
 ```
 
-- View the dashboard at [Codecov](https://codecov.io/gh/Limen-Neural/neuromod).
 - Open `target/llvm-cov/html/index.html` after running the HTML report locally.
 - CI runs the `coverage.yml` workflow on every PR and push to `main`.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ CI installs the same toolchain on each OS. Keep `Cargo.toml` `rust-version`, `ru
 
 ```toml
 [dependencies]
-neuromod = "0.5.1"
+neuromod = "0.5.2"
 ```
 
 Links: [crates.io](https://crates.io/crates/neuromod) · [docs.rs](https://docs.rs/neuromod) · [repository](https://github.com/Limen-Neural/neuromod)


### PR DESCRIPTION
## Summary

Bump the crate to **0.5.2** so the published/package version matches the v0.5.2 milestone work already on `main`.

* `Cargo.toml` → `version = "0.5.2"`
* README install pin → `neuromod = "0.5.2"`
* CHANGELOG: fold `[Unreleased]` into `## [0.5.2] - 2026-08-12` (aligned with current main):
  * sentry feature removed (Limen-Neural/neuromod#88)
  * cubic wiki untracked/excluded (Limen-Neural/neuromod#90)
  * rustdoc textbook spine + MSRV policy (Limen-Neural/neuromod#89, Limen-Neural/neuromod#79)
  * CI OS matrix Linux/macOS/Windows + docs (Limen-Neural/neuromod#94, Limen-Neural/neuromod#95)
  * domain docs scan uses `cargo doc --all-features --no-deps`

## Test plan

- [X] Version strings consistent (`Cargo.toml`, README, CHANGELOG)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.5.2`, GitHub Release, `cargo publish` (separate step)

---

## Summary by cubic

Release `neuromod` 0.5.2: bump versions in `Cargo.toml`/README, fold Unreleased into `0.5.2` in the CHANGELOG, and fix Codecov by using `CODECOV_TOKEN` for uploads, switching to the official graph badge token, and keeping uploads non-blocking (`fail_ci_if_error: false`). The coverage workflow now runs with least-privilege (`permissions: contents: read`), the README links the Codecov dashboard, and `Cargo.lock` reflects 0.5.2.

Written for commit ff6b24194e4016d2c861974d602eacbaab5effce. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)