### PR TITLE
ci(docker): dual-push to Docker Hub and GHCR (org packages)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,7 +126,6 @@ jobs:
           TAGS="${HUB}:${SHA},${HUB}:${VER},${HUB}:latest"
           TAGS="${TAGS},${GHCR}:${SHA},${GHCR}:${VER},${GHCR}:latest"
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-          echo "crate_version=${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 # Docker build + push (Docker Hub + GitHub Container Registry)
 # Third-party Actions are pinned to immutable commit SHAs (Aikido supply-chain policy).
 # Uses local Docker Buildx (no Build Cloud dependency).
+#
+# PR: verify build + load runtime image + run tests in builder stage (contents: read only).
+# main push: publish to Docker Hub + GHCR (packages: write only on that job).
 name: Docker Build & Push
 
 on:
@@ -10,14 +13,17 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
-# GHCR push needs packages:write; checkout only needs contents:read.
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  docker:
+  # Pull requests / any event: build & smoke-verify without package write.
+  docker-verify:
+    name: docker verify
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,15 +32,73 @@ jobs:
 
       - name: Log in to Docker Hub
         # Dependabot PRs lack secrets; same-repo human PRs keep authenticated pulls.
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
 
-      # Only push to GHCR from main (creates org package under Limen-Neural).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Set image tags
+        id: image
+        run: |
+          set -euo pipefail
+          SHA="${{ github.sha }}"
+          echo "tags=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
+          echo "verify_tag=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
+          echo "builder_tag=neuromod:builder-pr-${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build runtime image (load locally)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ steps.image.outputs.tags }}
+
+      - name: Verify runtime image contains example binaries
+        run: |
+          set -euo pipefail
+          docker run --rm "${{ steps.image.outputs.verify_tag }}" ls /usr/local/bin/
+
+      - name: Build builder stage and run cargo tests
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          load: true
+          target: builder
+          tags: ${{ steps.image.outputs.builder_tag }}
+
+      - name: cargo test --all-features in builder image
+        run: |
+          set -euo pipefail
+          docker run --rm "${{ steps.image.outputs.builder_tag }}" \
+            cargo test --all-features --quiet
+
+  # main only: dual-push to Docker Hub + GHCR.
+  docker-publish:
+    name: docker publish
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
       - name: Log in to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -49,34 +113,24 @@ jobs:
         run: |
           set -euo pipefail
           SHA="${{ github.sha }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "tags=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
-            echo "verify_tag=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
-            echo "push=false" >> "$GITHUB_OUTPUT"
-          else
-            VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
-            HUB="${{ vars.DOCKER_USER }}/neuromod"
-            # GHCR owner must be lowercase
-            GHCR="ghcr.io/limen-neural/neuromod"
-            # Hub: commit SHA (existing convention) + version + latest
-            # GHCR: same so the package appears under github.com/orgs/Limen-Neural/packages
-            TAGS="${HUB}:${SHA},${HUB}:${VER},${HUB}:latest"
-            TAGS="${TAGS},${GHCR}:${SHA},${GHCR}:${VER},${GHCR}:latest"
-            echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-            echo "verify_tag=${HUB}:${SHA}" >> "$GITHUB_OUTPUT"
-            echo "push=true" >> "$GITHUB_OUTPUT"
-            echo "crate_version=${VER}" >> "$GITHUB_OUTPUT"
+          VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Failed to extract a semver from Cargo.toml (got: ${VER:-empty})"
+            exit 1
           fi
+          HUB="${{ vars.DOCKER_USER }}/neuromod"
+          # GHCR owner must be lowercase
+          GHCR="ghcr.io/limen-neural/neuromod"
+          # Hub: commit SHA (existing convention) + version + latest
+          # GHCR: same so the package appears under github.com/orgs/Limen-Neural/packages
+          TAGS="${HUB}:${SHA},${HUB}:${VER},${HUB}:latest"
+          TAGS="${TAGS},${GHCR}:${SHA},${GHCR}:${VER},${GHCR}:latest"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "crate_version=${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: ${{ steps.image.outputs.push == 'true' }}
-          load: ${{ github.event_name == 'pull_request' }}
+          push: true
           tags: ${{ steps.image.outputs.tags }}
-
-      - name: Verify image builds example binary
-        if: github.event_name == 'pull_request'
-        run: |
-          docker run --rm "${{ steps.image.outputs.verify_tag }}" ls /usr/local/bin/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
-# Docker build + push
+# Docker build + push (Docker Hub + GitHub Container Registry)
 # Third-party Actions are pinned to immutable commit SHAs (Aikido supply-chain policy).
-# Uses local Docker Buildx + Docker Hub login (no Build Cloud dependency).
+# Uses local Docker Buildx (no Build Cloud dependency).
 name: Docker Build & Push
 
 on:
@@ -10,6 +10,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+# GHCR push needs packages:write; checkout only needs contents:read.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -18,6 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
       - name: Log in to Docker Hub
         # Dependabot PRs lack secrets; same-repo human PRs keep authenticated pulls.
         if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
@@ -25,24 +31,52 @@ jobs:
         with:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
+
+      # Only push to GHCR from main (creates org package under Limen-Neural).
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Set image tag
+
+      - name: Set image tags
         id: image
         run: |
+          set -euo pipefail
+          SHA="${{ github.sha }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "tag=neuromod:pr-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "tags=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
+            echo "verify_tag=neuromod:pr-${SHA}" >> "$GITHUB_OUTPUT"
+            echo "push=false" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ vars.DOCKER_USER }}/neuromod:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+            HUB="${{ vars.DOCKER_USER }}/neuromod"
+            # GHCR owner must be lowercase
+            GHCR="ghcr.io/limen-neural/neuromod"
+            # Hub: commit SHA (existing convention) + version + latest
+            # GHCR: same so the package appears under github.com/orgs/Limen-Neural/packages
+            TAGS="${HUB}:${SHA},${HUB}:${VER},${HUB}:latest"
+            TAGS="${TAGS},${GHCR}:${SHA},${GHCR}:${VER},${GHCR}:latest"
+            echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+            echo "verify_tag=${HUB}:${SHA}" >> "$GITHUB_OUTPUT"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            echo "crate_version=${VER}" >> "$GITHUB_OUTPUT"
           fi
+
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          push: ${{ steps.image.outputs.push == 'true' }}
           load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ steps.image.outputs.tag }}
-          outputs: ${{ github.event_name == 'pull_request' && 'type=docker' || 'type=registry' }}
+          tags: ${{ steps.image.outputs.tags }}
+
       - name: Verify image builds example binary
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm "${{ steps.image.outputs.tag }}" ls /usr/local/bin/
+          docker run --rm "${{ steps.image.outputs.verify_tag }}" ls /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Docker:** CI pushes example runtime images to Docker Hub and **GHCR** (`ghcr.io/limen-neural/neuromod` with SHA, version, and `latest` tags) so the image appears under GitHub org packages; README documents pull URLs.
+
 ## [0.5.2] - 2026-08-12
 
 Docs, CI, and packaging hygiene for the v0.5.2 milestone. Publish with `cargo publish` after this tag lands.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   - **GitHub Container Registry:** `ghcr.io/limen-neural/neuromod` (same tags) — listed under [org packages](https://github.com/orgs/Limen-Neural/packages)
 
   Pull (examples only — prefer the crates.io library for embedding):
+
   ```bash
   docker pull ghcr.io/limen-neural/neuromod:0.5.2
   # or Docker Hub:
@@ -262,6 +263,7 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   ```
 
   Local usage:
+
   ```bash
   # Runtime image (example binaries only — no cargo toolchain)
   docker build -t neuromod:runtime .

--- a/README.md
+++ b/README.md
@@ -249,7 +249,18 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   - CodeQL (`.github/workflows/codeql.yml`)
   - `rustsec/audit-check` + Trivy (`.github/workflows/audit.yml`)
 - **Dependencies**: Dependabot (`.github/dependabot.yml`) for Cargo, GitHub Actions, Docker.
-- **Docker** (`.github/workflows/docker.yml`, `Dockerfile`): Reproducible builds.
+- **Docker** (`.github/workflows/docker.yml`, `Dockerfile`): Reproducible **example** runtime image (not required for library use). On every push to `main`, CI builds and pushes to:
+  - **Docker Hub:** `pelon23/neuromod` (tags: commit SHA, crate version, `latest`)
+  - **GitHub Container Registry:** `ghcr.io/limen-neural/neuromod` (same tags) — listed under [org packages](https://github.com/orgs/Limen-Neural/packages)
+
+  Pull (examples only — prefer the crates.io library for embedding):
+  ```bash
+  docker pull ghcr.io/limen-neural/neuromod:0.5.2
+  # or Docker Hub:
+  docker pull pelon23/neuromod:0.5.2
+  docker run --rm ghcr.io/limen-neural/neuromod:0.5.2 ls /usr/local/bin
+  ```
+
   Local usage:
   ```bash
   # Runtime image (example binaries only — no cargo toolchain)
@@ -266,3 +277,5 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
 - Crates.io: https://crates.io/crates/neuromod
 - Docs.rs: https://docs.rs/neuromod
 - Repository: https://github.com/Limen-Neural/neuromod
+- GHCR: https://github.com/orgs/Limen-Neural/packages/container/package/neuromod
+- Docker Hub: https://hub.docker.com/r/pelon23/neuromod


### PR DESCRIPTION
## Summary

Publish the example runtime Docker image to **GitHub Container Registry** as well as Docker Hub so it shows up under [org packages](https://github.com/orgs/Limen-Neural/packages).

* On `main` push: login to Docker Hub + `ghcr.io` (`GITHUB_TOKEN`, `packages: write`)
* Tags: commit SHA, crate version from `Cargo.toml`, and `latest` on both registries
* PR builds stay local (verify example binaries only)
* README + CHANGELOG document pull URLs

**Pull after merge:**
```bash
docker pull ghcr.io/limen-neural/neuromod:0.5.2
docker pull pelon23/neuromod:0.5.2
```

## Test plan

- [ ] PR Docker job green (build + `ls /usr/local/bin`)
- [ ] After merge: image appears at https://github.com/orgs/Limen-Neural/packages
- [ ] `docker pull ghcr.io/limen-neural/neuromod:latest` works (may need package visibility set to public once)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now dual-pushes the example runtime Docker image to Docker Hub and GHCR under org packages with SHA, version, and latest tags. PRs run local builds and cargo tests with least-privilege; only `main` pushes.

- **New Features**
  - Split workflow: `docker-verify` for PRs (`contents: read`), `docker-publish` on `main` (`packages: write`).
  - PRs: build and load runtime image, verify example binaries, build `builder` target and run `cargo test --all-features`; no push.
  - Publish: push to `pelon23/neuromod` and `ghcr.io/limen-neural/neuromod` with SHA, crate version from `Cargo.toml`, and `latest`; GHCR login via `GITHUB_TOKEN`, Docker Hub via `DOCKER_USER`/`DOCKER_PAT`.
  - Hardened version parsing (fail if not valid semver) and removed unused `crate_version` output; README and CHANGELOG list pull URLs and package links.

<sup>Written for commit bafd2414c57d003a14fcb1e76135c280b8eee4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/neuromod/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

