### PR TITLE
fix: README 0.5.2 links + Docker verify (cubic #97 follow-up)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,9 +123,9 @@ jobs:
           set -euo pipefail
           SHA="${{ github.sha }}"
           VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          # Full match only: X.Y.Z (no trailing junk; +meta would be invalid Docker tags).
-          # Escape $ so YAML/shell do not strip the end-of-string anchor.
-          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\$'; then
+          # Full match only: X.Y.Z. Use single-quoted ERE so `$` is end-of-string
+          # (not shell-expanded). Do NOT write `\$` — that matches a literal `$`.
+          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Failed to extract a semver X.Y.Z from Cargo.toml (got: ${VER:-empty})"
             exit 1
           fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,16 @@ jobs:
       - name: Verify runtime image contains example binaries
         run: |
           set -euo pipefail
-          docker run --rm "${{ steps.image.outputs.verify_tag }}" ls /usr/local/bin/
+          # Fail if no executables (bare `ls` succeeds on empty dir).
+          out=$(docker run --rm "${{ steps.image.outputs.verify_tag }}" \
+            sh -c 'ls -1 /usr/local/bin | wc -l')
+          test "${out}" -ge 1
+          # Known example binaries from examples/*.rs
+          for bin in basic basic_lif hebbian_learning rstdp_demo; do
+            docker run --rm "${{ steps.image.outputs.verify_tag }}" \
+              sh -c "test -x /usr/local/bin/${bin}"
+          done
+          docker run --rm "${{ steps.image.outputs.verify_tag }}" ls -la /usr/local/bin/
 
       - name: Build builder stage and run cargo tests
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -114,8 +123,9 @@ jobs:
           set -euo pipefail
           SHA="${{ github.sha }}"
           VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "::error::Failed to extract a semver from Cargo.toml (got: ${VER:-empty})"
+          # Full match only: X.Y.Z (no trailing junk; +meta would be invalid Docker tags).
+          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Failed to extract a semver X.Y.Z from Cargo.toml (got: ${VER:-empty})"
             exit 1
           fi
           HUB="${{ vars.DOCKER_USER }}/neuromod"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,7 +124,8 @@ jobs:
           SHA="${{ github.sha }}"
           VER=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
           # Full match only: X.Y.Z (no trailing junk; +meta would be invalid Docker tags).
-          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # Escape $ so YAML/shell do not strip the end-of-string anchor.
+          if [ -z "${VER}" ] || ! printf '%s' "${VER}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\$'; then
             echo "::error::Failed to extract a semver X.Y.Z from Cargo.toml (got: ${VER:-empty})"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 
 - **Docker:** CI pushes example runtime images to Docker Hub and **GHCR** (`ghcr.io/limen-neural/neuromod` with SHA, version, and `latest` tags) so the image appears under GitHub org packages; README documents pull URLs.
 - **Docker verify:** PR job asserts example binaries exist in the runtime image; publish job requires full `X.Y.Z` crate version for tags.
-- README crates.io / docs.rs badge links point at the **0.5.2** release.
+- README crates.io / docs.rs badges stay version-agnostic (latest); install pin documents **0.5.2**.
 
 ## [0.5.2] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - **Docker:** CI pushes example runtime images to Docker Hub and **GHCR** (`ghcr.io/limen-neural/neuromod` with SHA, version, and `latest` tags) so the image appears under GitHub org packages; README documents pull URLs.
+- **Docker verify:** PR job asserts example binaries exist in the runtime image; publish job requires full `X.Y.Z` crate version for tags.
+- README crates.io / docs.rs badge links point at the **0.5.2** release.
 
 ## [0.5.2] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # neuromod
 
-[![Crates.io](https://img.shields.io/crates/v/neuromod.svg?label=crates.io)](https://crates.io/crates/neuromod/0.5.2)
-[![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod/0.5.2/neuromod/)
+[![Crates.io](https://img.shields.io/crates/v/neuromod.svg?label=crates.io)](https://crates.io/crates/neuromod)
+[![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod)
 [![License](https://img.shields.io/crates/l/neuromod.svg)](https://github.com/Limen-Neural/neuromod#license)
 [![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg?token=V0U0K5P6PW)](https://codecov.io/gh/Limen-Neural/neuromod)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # neuromod
 
-[![Crates.io](https://img.shields.io/crates/v/neuromod.svg)](https://crates.io/crates/neuromod)
-[![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod)
+[![Crates.io](https://img.shields.io/crates/v/neuromod.svg?label=crates.io)](https://crates.io/crates/neuromod/0.5.2)
+[![docs.rs](https://docs.rs/neuromod/badge.svg)](https://docs.rs/neuromod/0.5.2/neuromod/)
 [![License](https://img.shields.io/crates/l/neuromod.svg)](https://github.com/Limen-Neural/neuromod#license)
 [![codecov](https://codecov.io/gh/Limen-Neural/neuromod/graph/badge.svg?token=V0U0K5P6PW)](https://codecov.io/gh/Limen-Neural/neuromod)
 


### PR DESCRIPTION
## Summary

- README crates.io / docs.rs badge **links** target **0.5.2** (install pin was already 0.5.2; shields may cache the SVG).
- Address unresolved **cubic** notes from #97:
  - PR Docker verify: require ≥1 binary and `basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo` executable
  - Publish tags: semver regex fully anchored `^[0-9]+\.[0-9]+\.[0-9]+$`

## Test plan

- [ ] Docker verify job fails if `/usr/local/bin` empty
- [ ] CI green on this PR
- [ ] Hard-refresh GitHub README if crates badge still shows old version (shields already reports v0.5.2)

Refs: Limen-Neural/neuromod#97 cubic threads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI hardening only; no library, auth, or runtime behavior changes. Slightly stricter Docker verify/tag validation may fail CI if binaries or version parsing regress.
> 
> **Overview**
> Tightens Docker CI checks and points README release badges at **0.5.2**.
> 
> The PR verify job now fails on an empty `/usr/local/bin` and asserts the known example binaries (`basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo`) are executable. Publish tagging requires a fully anchored `X.Y.Z` crate version.
> 
> Also updates crates.io / docs.rs badge **links** to the 0.5.2 pages and notes the changes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8ed393cdcb051cbf1385ac30118d6e79dcb52f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Docker CI to verify example binaries and enforce a fully anchored X.Y.Z version tag. README badges remain version-agnostic; install pin stays 0.5.2. Follow-up to cubic #97 to ensure runtime images ship runnable examples and tags match the crate version.

- **Bug Fixes**
  - Docker verify: fail if `/usr/local/bin` is empty and ensure `basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo` are executable.
  - Tagging: require full `X.Y.Z` with an end-anchored regex using a single-quoted grep pattern (no `$` escaping); crates.io/docs.rs badges point to latest.

<sup>Written for commit e3f9255ee99098e0a7c3c4f5ae62571ac4e59bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/neuromod/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

