### PR TITLE
feat(rm-stdp): wire eligibility traces into the engine learning path (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project are documented in this file.
   `stdp_config` rather than the `RM_STDP_W_MIN` / `RM_STDP_W_MAX` constants directly, in both
   `apply_stdp` and the L1 renormalization pass (the constants remain public and are the
   defaults) (#72, #73).
+- **Breaking (source, targets 0.6.0):** `LifNeuron` and `SpikingNetwork` have public fields
+  and are not `#[non_exhaustive]`, so the new `eligibility` / `stdp_config` fields break
+  downstream struct literals that spell out every field. Serialized state is unaffected.
+  Fill the remainder from `..LifNeuron::new()` / `..Default::default()`, or build through the
+  constructors; see the README migration notes (#72, #73).
+- Weight bounds now take documented precedence over the engine's L1 weight budget: `step`
+  scales toward the budget and then clamps, so a narrowed `w_min` / `w_max` leaves the sum
+  off budget. The defaults cannot bind, so the budget still holds exactly under them.
 - `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
   instead of narrating hardcoded claims about learning.
 - Docs no longer carry the "eligibility traces are not wired" caveat: crate root, `engine`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ All notable changes to this project are documented in this file.
   post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a
   pre-0.6 checkpoint without the new fields still deserializes and steps (#74).
 - Benchmarks for trace accumulation, the trace → weight conversion, and rewarded vs
-  unrewarded engine steps (`benches/stdp_bench.rs`).
+  unrewarded engine steps (`benches/stdp_bench.rs`). The engine-step benches warm the network
+  to steady state first: `apply_stdp` skips the decay `exp` while a trace is still exactly
+  zero, so timing from a blank network would measure that transient instead of the per-step
+  cost of a running one.
 - [ADR 002](docs/adr/002-wire-eligibility-traces.md) recording the wire-vs-demote decision.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,12 @@ All notable changes to this project are documented in this file.
   `accumulate`; converting it produced a `NaN` weight (`f32::clamp` preserves `NaN`) and the
   L1 pass then skipped that neuron permanently. Clearing lets the synapse learn again.
 - `RmStdpConfig::effective_tau_eligibility` — same guard for `tau_eligibility`, and
-  `EligibilityTrace::decay` now falls back the same way. A `NaN` tau used to erase every
-  banked trace on the next step (`exp(-1/f32::EPSILON) == 0`) and `+∞` disabled decay
-  entirely; both now degrade to `RM_STDP_TAU_ELIGIBILITY`.
+  `EligibilityTrace::decay` now falls back the same way. `decay` multiplies by
+  `exp(-1/tau)`, so a `NaN` tau used to propagate `NaN` into every banked trace on the next
+  step (which is what left `apply_stdp` with non-finite values to clear), `+∞` disabled decay
+  entirely, `0.0` erased every trace at once, and a negative tau grew them without bound. All
+  four now degrade to `RM_STDP_TAU_ELIGIBILITY`; a tiny *positive* tau is still honored, since
+  "no memory" is a legitimate setting.
 - Tests proving the reward-gated path: traces accumulate with dopamine off while weights
   hold, dopamine converts the banked trace (and more dopamine buys more learning),
   post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a
@@ -84,6 +87,10 @@ All notable changes to this project are documented in this file.
   `w_min`; and a depressing update (`dw < 0`) clamped up to `w_min` as well, connecting a
   synapse by weakening it. Either way the L1 pass then scaled the fabricated weight toward the
   budget. The floor still binds wherever an update actually applies.
+- `apply_stdp` decays eligibility traces past the last input channel as well. A caller can
+  give a neuron more weights than the network has channels; those synapses have no input that
+  could ever spike, and the per-channel loop stopped before reaching them, so a planted or
+  deserialized trace stayed frozen there across every step.
 - `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
   instead of narrating hardcoded claims about learning. Its `RmStdpConfig` scenario runs the
   reconfigured network and an otherwise identical default-config twin through the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ All notable changes to this project are documented in this file.
   to `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
   non-finite (either would panic `f32::clamp` inside `step`), or when `w_min` is negative.
   This crate does not support inhibitory weights: a negative floor lets a rewarded depression
-  flip a synapse's sign, and once a neuron's weights sum negative the L1 renormalization pass
-  skips it permanently, since `total > 1e-6` is never true again.
+  flip a synapse's sign, and the L1 renormalization pass then skips that neuron for as long as
+  its weights sum non-positive. A wholly negative range such as `(-2.0, -1.0)` makes that
+  permanent — every update clamps back inside it, so the total can never climb — while a range
+  merely straddling zero stalls normalization until later potentiation restores a positive
+  total.
 - `RmStdpConfig::effective_reward_lr` — same guard for a non-finite `reward_lr`. A `NaN`
   rate would poison a weight on the first rewarded step and never clear, because the L1
   renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ All notable changes to this project are documented in this file.
 - `EligibilityTrace::new` / `kernel` / `accumulate` / `reset`, plus `Default` impls for
   `EligibilityTrace` and `RmStdpConfig`, and the `RM_STDP_TAU_ELIGIBILITY` /
   `RM_STDP_REWARD_LR` constants behind those defaults.
-- `RmStdpConfig::weight_bounds` — ordered `(min, max)` accessor that falls back to
-  `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
-  non-finite, so a hand-edited config cannot panic `f32::clamp` inside `step`.
+- `RmStdpConfig::weight_bounds` — ordered, non-negative `(min, max)` accessor that falls back
+  to `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
+  non-finite (either would panic `f32::clamp` inside `step`), or when `w_min` is negative.
+  This crate does not support inhibitory weights: a negative floor lets a rewarded depression
+  flip a synapse's sign, and once a neuron's weights sum negative the L1 renormalization pass
+  skips it permanently, since `total > 1e-6` is never true again.
 - `RmStdpConfig::effective_reward_lr` — same guard for a non-finite `reward_lr`. A `NaN`
   rate would poison a weight on the first rewarded step and never clear, because the L1
   renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ All notable changes to this project are documented in this file.
   rate would poison a weight on the first rewarded step and never clear, because the L1
   renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is
   false. Finite negative rates still pass through.
+- `apply_stdp` clears a non-finite `EligibilityTrace::value` instead of paying it out.
+  `value` is public and deserializable, so a `NaN` can arrive without passing through
+  `accumulate`; converting it produced a `NaN` weight (`f32::clamp` preserves `NaN`) and the
+  L1 pass then skipped that neuron permanently. Clearing lets the synapse learn again.
 - `RmStdpConfig::effective_tau_eligibility` — same guard for `tau_eligibility`, and
   `EligibilityTrace::decay` now falls back the same way. A `NaN` tau used to erase every
   banked trace on the next step (`exp(-1/f32::EPSILON) == 0`) and `+∞` disabled decay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to this project are documented in this file.
   rate would poison a weight on the first rewarded step and never clear, because the L1
   renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is
   false. Finite negative rates still pass through.
+- `EligibilityTrace::kernel` returns `0.0` for a non-finite `delta_t` — no usable timing means
+  no credit. The engine cannot produce one (it subtracts two `i64` step counters), but `kernel`
+  and `accumulate` are public: `NaN` took the depression branch (`NaN >= 0.0` is false) and
+  poisoned whichever trace it landed in.
 - `apply_stdp` clears a non-finite `EligibilityTrace::value` instead of paying it out.
   `value` is public and deserializable, so a `NaN` can arrive without passing through
   `accumulate`; converting it produced a `NaN` weight (`f32::clamp` preserves `NaN`) and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project are documented in this file.
 - `RmStdpConfig::weight_bounds` — ordered `(min, max)` accessor that falls back to
   `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
   non-finite, so a hand-edited config cannot panic `f32::clamp` inside `step`.
+- `RmStdpConfig::effective_reward_lr` — same guard for a non-finite `reward_lr`. A `NaN`
+  rate would poison a weight on the first rewarded step and never clear, because the L1
+  renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is
+  false. Finite negative rates still pass through.
 - Tests proving the reward-gated path: traces accumulate with dopamine off while weights
   hold, dopamine converts the banked trace (and more dopamine buys more learning),
   post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ All notable changes to this project are documented in this file.
   and are not `#[non_exhaustive]`, so the new `eligibility` / `stdp_config` fields break
   downstream struct literals that spell out every field. Fill the remainder from
   `..LifNeuron::new()` / `..Default::default()`, or build through the constructors. Serialized
-  state survives in self-describing formats (JSON, YAML, RON, map-encoded MessagePack) via
-  `#[serde(default)]`; positional binary formats such as `bincode` / `postcard` cannot use
-  those defaults and will not load pre-0.6 bytes. See the README migration notes (#72, #73).
+  state written by 0.5.x stays *deserializable* in self-describing formats (JSON, YAML, RON,
+  map-encoded MessagePack) via `#[serde(default)]`; positional binary formats such as
+  `bincode` / `postcard` cannot use those defaults and will not load pre-0.6 bytes. The
+  serialized shape does change — checkpoints written by 0.6 carry `eligibility` and
+  `stdp_config`, so they will not load into 0.5.x. See the README migration notes (#72, #73).
 - Weight bounds now take documented precedence over the engine's L1 weight budget: `step`
   scales toward the budget and then clamps, so a narrowed `w_min` / `w_max` leaves the sum
   off budget. The defaults cannot bind, so the budget still holds exactly under them. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project are documented in this file.
   rate would poison a weight on the first rewarded step and never clear, because the L1
   renormalization pass skips any neuron whose total is not `> 1e-6` and `NaN > 1e-6` is
   false. Finite negative rates still pass through.
+- `RmStdpConfig::effective_tau_eligibility` — same guard for `tau_eligibility`, and
+  `EligibilityTrace::decay` now falls back the same way. A `NaN` tau used to erase every
+  banked trace on the next step (`exp(-1/f32::EPSILON) == 0`) and `+∞` disabled decay
+  entirely; both now degrade to `RM_STDP_TAU_ELIGIBILITY`.
 - Tests proving the reward-gated path: traces accumulate with dopamine off while weights
   hold, dopamine converts the banked trace (and more dopamine buys more learning),
   post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a
@@ -42,12 +46,17 @@ All notable changes to this project are documented in this file.
   defaults) (#72, #73).
 - **Breaking (source, targets 0.6.0):** `LifNeuron` and `SpikingNetwork` have public fields
   and are not `#[non_exhaustive]`, so the new `eligibility` / `stdp_config` fields break
-  downstream struct literals that spell out every field. Serialized state is unaffected.
-  Fill the remainder from `..LifNeuron::new()` / `..Default::default()`, or build through the
-  constructors; see the README migration notes (#72, #73).
+  downstream struct literals that spell out every field. Fill the remainder from
+  `..LifNeuron::new()` / `..Default::default()`, or build through the constructors. Serialized
+  state survives in self-describing formats (JSON, YAML, RON, map-encoded MessagePack) via
+  `#[serde(default)]`; positional binary formats such as `bincode` / `postcard` cannot use
+  those defaults and will not load pre-0.6 bytes. See the README migration notes (#72, #73).
 - Weight bounds now take documented precedence over the engine's L1 weight budget: `step`
   scales toward the budget and then clamps, so a narrowed `w_min` / `w_max` leaves the sum
-  off budget. The defaults cannot bind, so the budget still holds exactly under them.
+  off budget. The defaults cannot bind, so the budget still holds exactly under them. The
+  renormalization pass leaves a synapse at exactly zero alone, so a positive `w_min` cannot
+  conjure a connection on an unrewarded step; learning raises a synapse to the floor in the
+  reward-gated `apply_stdp` instead.
 - `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
   instead of narrating hardcoded claims about learning.
 - Docs no longer carry the "eligibility traces are not wired" caveat: crate root, `engine`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,15 @@ All notable changes to this project are documented in this file.
   off budget. The defaults cannot bind, so the budget still holds exactly under them. The
   renormalization pass leaves a synapse at exactly zero alone, so a positive `w_min` cannot
   conjure a connection on an unrewarded step; learning raises a synapse to the floor in the
-  reward-gated `apply_stdp` instead.
+  reward-gated `apply_stdp` instead. `apply_stdp` in turn writes only when the update is
+  non-zero, so `reward_lr = 0.0` really disables conversion: without that check a positive
+  `w_min` clamped an unconnected synapse up to the floor even though no credit was converted,
+  and the L1 pass then scaled the fabricated weight toward the budget.
 - `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
-  instead of narrating hardcoded claims about learning.
+  instead of narrating hardcoded claims about learning. Its `RmStdpConfig` scenario runs the
+  reconfigured network and an otherwise identical default-config twin through the same
+  rewarded steps, so the slower payout and the longer-held trace are measured rather than
+  asserted.
 - Docs no longer carry the "eligibility traces are not wired" caveat: crate root, `engine`,
   `lif`, and `rm_stdp` rustdoc, `README.md`, `CLAUDE.md`, and the `REVIEW.md` regression
   guards describe (and guard) the wired path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,43 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **R-STDP is wired into the engine.** `LifNeuron` gains `eligibility: Vec<EligibilityTrace>`
+  (one trace per input channel, indexed like `weights`) and `SpikingNetwork` gains
+  `stdp_config: RmStdpConfig`. `SpikingNetwork::apply_stdp` now decays and accumulates those
+  traces on every step and converts them into weight changes under the dopamine gate, so
+  reward arriving *after* a coincidence still pays for it (#72, #73).
+- `SpikingNetwork::set_rm_stdp_config` — replace the R-STDP hyperparameters and re-`tau`
+  existing traces in one call.
+- `EligibilityTrace::new` / `kernel` / `accumulate` / `reset`, plus `Default` impls for
+  `EligibilityTrace` and `RmStdpConfig`, and the `RM_STDP_TAU_ELIGIBILITY` /
+  `RM_STDP_REWARD_LR` constants behind those defaults.
+- `RmStdpConfig::weight_bounds` — ordered `(min, max)` accessor that falls back to
+  `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
+  non-finite, so a hand-edited config cannot panic `f32::clamp` inside `step`.
+- Tests proving the reward-gated path: traces accumulate with dopamine off while weights
+  hold, dopamine converts the banked trace (and more dopamine buys more learning),
+  post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a
+  pre-0.6 checkpoint without the new fields still deserializes and steps (#74).
+- Benchmarks for trace accumulation, the trace → weight conversion, and rewarded vs
+  unrewarded engine steps (`benches/stdp_bench.rs`).
+- [ADR 002](docs/adr/002-wire-eligibility-traces.md) recording the wire-vs-demote decision.
+
 ### Changed
 
+- **Breaking (targets 0.6.0):** weight updates flow through a decaying eligibility trace
+  instead of being recomputed from raw spike times each step, so same-input runs will not
+  reproduce pre-0.6 weight trajectories. `apply_stdp` no longer early-returns when dopamine
+  is ~0 — only the trace → weight conversion is gated. Weight bounds now come from
+  `stdp_config` rather than the `RM_STDP_W_MIN` / `RM_STDP_W_MAX` constants directly, in both
+  `apply_stdp` and the L1 renormalization pass (the constants remain public and are the
+  defaults) (#72, #73).
+- `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
+  instead of narrating hardcoded claims about learning.
+- Docs no longer carry the "eligibility traces are not wired" caveat: crate root, `engine`,
+  `lif`, and `rm_stdp` rustdoc, `README.md`, `CLAUDE.md`, and the `REVIEW.md` regression
+  guards describe (and guard) the wired path.
 - **Docker:** CI pushes example runtime images to Docker Hub and **GHCR** (`ghcr.io/limen-neural/neuromod` with SHA, version, and `latest` tags) so the image appears under GitHub org packages; README documents pull URLs.
 - **Docker verify:** PR job asserts example binaries exist in the runtime image; publish job requires full `X.Y.Z` crate version for tags.
 - README crates.io / docs.rs badges stay version-agnostic (latest); install pin documents **0.5.2**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@ literals and for weight trajectories; see the README migration notes. Publish wi
   and are not `#[non_exhaustive]`, so the new `eligibility` / `stdp_config` fields break
   downstream struct literals that spell out every field. Fill the remainder from
   `..LifNeuron::new()` / `..Default::default()`, or build through the constructors. Serialized
-  state written by 0.5.x stays *deserializable* in self-describing formats (JSON, YAML, RON,
-  map-encoded MessagePack) via `#[serde(default)]`; positional binary formats such as
+  state written by 0.5.x stays *deserializable* in self-describing formats (JSON, YAML,
+  TOML, RON, map-encoded MessagePack) via `#[serde(default)]`; positional binary formats such as
   `bincode` / `postcard` cannot use those defaults and will not load pre-0.6 bytes. The
   serialized shape does change — checkpoints written by 0.6 carry `eligibility` and
   `stdp_config`, so they will not load into 0.5.x. See the README migration notes (#72, #73).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,12 @@ All notable changes to this project are documented in this file.
   post-before-pre depresses and clamps at `w_min`, one spike pair is counted once, and a
   pre-0.6 checkpoint without the new fields still deserializes and steps (#74).
 - Benchmarks for trace accumulation, the trace → weight conversion, and rewarded vs
-  unrewarded engine steps (`benches/stdp_bench.rs`). The engine-step benches warm the network
-  to steady state first: `apply_stdp` skips the decay `exp` while a trace is still exactly
-  zero, so timing from a blank network would measure that transient instead of the per-step
-  cost of a running one.
+  unrewarded engine steps (`benches/stdp_bench.rs`), listed in `benches/README.md`. The
+  engine-step benches warm the network to steady state first: `apply_stdp` skips the decay
+  `exp` while a trace is still exactly zero, so timing from a blank network would measure that
+  transient instead of the per-step cost of a running one. The conversion bench is batched
+  rather than carrying its weight across iterations, which would pin it at `w_max` within a
+  couple of hundred samples and time a saturated synapse.
 - [ADR 002](docs/adr/002-wire-eligibility-traces.md) recording the wire-vs-demote decision.
 
 ### Changed
@@ -75,10 +77,13 @@ All notable changes to this project are documented in this file.
   off budget. The defaults cannot bind, so the budget still holds exactly under them. The
   renormalization pass leaves a synapse at exactly zero alone, so a positive `w_min` cannot
   conjure a connection on an unrewarded step; learning raises a synapse to the floor in the
-  reward-gated `apply_stdp` instead. `apply_stdp` in turn writes only when the update is
-  non-zero, so `reward_lr = 0.0` really disables conversion: without that check a positive
-  `w_min` clamped an unconnected synapse up to the floor even though no credit was converted,
-  and the L1 pass then scaled the fabricated weight toward the budget.
+  reward-gated `apply_stdp` instead, and only through potentiation. Both paths that touch a
+  weight now agree that exactly zero means unconnected and that the bounds never move a weight
+  on their own. Writing unconditionally let them do so twice over on a zero-weight synapse:
+  `reward_lr = 0.0` disables conversion, yet a `dw` of zero still clamped up to a positive
+  `w_min`; and a depressing update (`dw < 0`) clamped up to `w_min` as well, connecting a
+  synapse by weakening it. Either way the L1 pass then scaled the fabricated weight toward the
+  budget. The floor still binds wherever an update actually applies.
 - `examples/rstdp_demo.rs` prints real trace and weight numbers read back from the network
   instead of narrating hardcoded claims about learning. Its `RmStdpConfig` scenario runs the
   reconfigured network and an otherwise identical default-config twin through the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.6.0] - 2026-08-29
+
+Reward-modulated STDP wired into the engine learning path. Breaking for downstream struct
+literals and for weight trajectories; see the README migration notes. Publish with
+`cargo publish` after this tag lands.
 
 ### Added
 
@@ -19,11 +23,13 @@ All notable changes to this project are documented in this file.
 - `RmStdpConfig::weight_bounds` — ordered, non-negative `(min, max)` accessor that falls back
   to `RM_STDP_W_MIN` / `RM_STDP_W_MAX` when the public bound fields are left reversed or
   non-finite (either would panic `f32::clamp` inside `step`), or when `w_min` is negative.
-  This crate does not support inhibitory weights: a negative floor lets a rewarded depression
-  flip a synapse's sign, and the L1 renormalization pass then skips that neuron for as long as
-  its weights sum non-positive. A wholly negative range such as `(-2.0, -1.0)` makes that
-  permanent — every update clamps back inside it, so the total can never climb — while a range
-  merely straddling zero stalls normalization until later potentiation restores a positive
+  Because of that fallback a negative bound never reaches `clamp`; the rest of this entry
+  describes what the guard prevents, not live behavior. This crate does not support inhibitory
+  weights: an honored negative floor would let a rewarded depression flip a synapse's sign, and
+  the L1 renormalization pass would then skip that neuron for as long as its weights summed
+  non-positive. A wholly negative range such as `(-2.0, -1.0)` would make that permanent —
+  every update clamps back inside it, so the total could never climb — while a range merely
+  straddling zero would stall normalization until later potentiation restored a positive
   total.
 - `RmStdpConfig::effective_reward_lr` — same guard for a non-finite `reward_lr`. A `NaN`
   rate would poison a weight on the first rewarded step and never clear, because the L1
@@ -59,14 +65,14 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
-- **Breaking (targets 0.6.0):** weight updates flow through a decaying eligibility trace
+- **Breaking:** weight updates flow through a decaying eligibility trace
   instead of being recomputed from raw spike times each step, so same-input runs will not
   reproduce pre-0.6 weight trajectories. `apply_stdp` no longer early-returns when dopamine
   is ~0 — only the trace → weight conversion is gated. Weight bounds now come from
   `stdp_config` rather than the `RM_STDP_W_MIN` / `RM_STDP_W_MAX` constants directly, in both
   `apply_stdp` and the L1 renormalization pass (the constants remain public and are the
   defaults) (#72, #73).
-- **Breaking (source, targets 0.6.0):** `LifNeuron` and `SpikingNetwork` have public fields
+- **Breaking (source):** `LifNeuron` and `SpikingNetwork` have public fields
   and are not `#[non_exhaustive]`, so the new `eligibility` / `stdp_config` fields break
   downstream struct literals that spell out every field. Fill the remainder from
   `..LifNeuron::new()` / `..Default::default()`, or build through the constructors. Serialized
@@ -101,7 +107,7 @@ All notable changes to this project are documented in this file.
   guards describe (and guard) the wired path.
 - **Docker:** CI pushes example runtime images to Docker Hub and **GHCR** (`ghcr.io/limen-neural/neuromod` with SHA, version, and `latest` tags) so the image appears under GitHub org packages; README documents pull URLs.
 - **Docker verify:** PR job asserts example binaries exist in the runtime image; publish job requires full `X.Y.Z` crate version for tags.
-- README crates.io / docs.rs badges stay version-agnostic (latest); install pin documents **0.5.2**.
+- README crates.io / docs.rs badges stay version-agnostic (latest); install pin documents **0.6.0**.
 
 ## [0.5.2] - 2026-08-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,12 @@ What `apply_stdp` does each step:
 - Accumulates a coincidence *only on the step a spike occurs*. Post fired now → `Δt ≥ 0`, potentiation. Pre fired now after an earlier post → `Δt < 0`, depression.
 - Converts traces to weights only when dopamine is present: `w += reward_lr · dopamine_lr · trace`.
 
-Both new fields are `#[serde(default)]`. `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints load from self-describing formats (JSON, YAML, RON). Positional binary formats (`bincode`, `postcard`) hit end-of-input before the new fields, so `#[serde(default)]` cannot rescue those — re-serialize from 0.5.x. Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
+Both new fields are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector. So pre-0.6 checkpoints still load, with one exception:
+
+- Self-describing formats — JSON, YAML, RON (Rusty Object Notation) — deserialize unchanged.
+- Positional binary formats (`bincode`, `postcard`) hit end-of-input before the new fields. `#[serde(default)]` cannot rescue those; re-serialize from 0.5.x.
+
+Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
 
 ### Neuromodulators are domain-agnostic by design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,20 @@ Returns the indices of LIF neurons that fired this step.
 
 - **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
 - **Reward-modulated STDP (R-STDP)** — constants, `EligibilityTrace`, and `RmStdpConfig` live in `src/rm_stdp.rs`; the live per-step rule is `SpikingNetwork::apply_stdp` (`src/engine.rs`).
-- Eligibility traces **are** live. Each `LifNeuron` holds `eligibility: Vec<EligibilityTrace>` indexed like `weights`; `SpikingNetwork` holds an `stdp_config: RmStdpConfig`. Every step decays each trace and accumulates a coincidence *only on the step a spike occurs* (post fired now → `Δt ≥ 0`, potentiation; pre fired now after an earlier post → `Δt < 0`, depression). Dopamine gates only `w += reward_lr · dopamine_lr · trace`. Both fields are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints still load. See [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
+- Eligibility traces **are** live — wired into the engine, not decorative.
+
+Where the R-STDP state lives:
+
+- `LifNeuron` holds `eligibility: Vec<EligibilityTrace>`, indexed like `weights`.
+- `SpikingNetwork` holds an `stdp_config: RmStdpConfig`.
+
+What `apply_stdp` does each step:
+
+- Decays every trace.
+- Accumulates a coincidence *only on the step a spike occurs*. Post fired now → `Δt ≥ 0`, potentiation. Pre fired now after an earlier post → `Δt < 0`, depression.
+- Converts traces to weights only when dopamine is present: `w += reward_lr · dopamine_lr · trace`.
+
+Both new fields are `#[serde(default)]`. `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints still load. Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
 
 ### Neuromodulators are domain-agnostic by design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,8 @@ Construction is topology-neutral. `new()` is the legacy default (16 LIF, 5 Izhik
 3. Update `predictive_state` (exponential moving average (EMA) per channel) and derive `pred_errors` ("surprise") that boost synaptic drive.
 4. Stochastically encode `stimuli` into `input_spike_times` (Poisson-style, probability proportional to stimulus magnitude).
 5. Integrate LIF membrane potentials, fire (`check_fire`), apply lateral inhibition to non-firing LIF neurons.
-6. Apply reward-modulated STDP (`apply_stdp`, gated by `dopamine`-derived `learning_rate`; skipped entirely if learning rate ≈ 0).
-7. Re-normalize each neuron's weights to `WEIGHT_BUDGET` (L1 budget) and clamp to `RM_STDP_W_MIN..RM_STDP_W_MAX`.
+6. Apply reward-modulated STDP (`apply_stdp`). Runs every step: per-synapse eligibility traces decay and accumulate regardless of dopamine; the `dopamine`-derived `learning_rate` gates only the trace → weight conversion.
+7. Re-normalize each neuron's weights to `WEIGHT_BUDGET` (L1 budget) and clamp to the `stdp_config` bounds (`RmStdpConfig::w_min`/`w_max`).
 8. Drive the Izhikevich bank from the mean LIF membrane potential + dopamine (`iz_drive`), independent of the LIF spike/STDP pipeline.
 
 Returns the indices of LIF neurons that fired this step.
@@ -83,8 +83,8 @@ Returns the indices of LIF neurons that fired this step.
 ### Two separate STDP implementations — do not conflate them
 
 - **Classical/unmodulated Hebbian STDP** — `src/hebbian/classical.rs` (`apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`). Pure Hebb's rule, no reward gating; the "biological root."
-- **Reward-modulated STDP (R-STDP)** — constants and `EligibilityTrace`/`RmStdpConfig` types live in `src/rm_stdp.rs`. The live per-step learning rule is inlined in `SpikingNetwork::apply_stdp` (`src/engine.rs`), gated by dopamine.
-- The R-STDP engine path was reconstructed after going missing; `EligibilityTrace` is not yet wired into `apply_stdp`. Weight updates currently happen directly rather than via eligibility-trace-then-reward-conversion. Do not assume eligibility traces are live.
+- **Reward-modulated STDP (R-STDP)** — constants, `EligibilityTrace`, and `RmStdpConfig` live in `src/rm_stdp.rs`; the live per-step rule is `SpikingNetwork::apply_stdp` (`src/engine.rs`).
+- Eligibility traces **are** live. Each `LifNeuron` holds `eligibility: Vec<EligibilityTrace>` indexed like `weights`; `SpikingNetwork` holds an `stdp_config: RmStdpConfig`. Every step decays each trace and accumulates a coincidence *only on the step a spike occurs* (post fired now → `Δt ≥ 0`, potentiation; pre fired now after an earlier post → `Δt < 0`, depression). Dopamine gates only `w += reward_lr · dopamine_lr · trace`. Both fields are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints still load. See [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
 
 ### Neuromodulators are domain-agnostic by design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ What `apply_stdp` does each step:
 
 Both new fields are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector. So pre-0.6 checkpoints still load, with one exception:
 
-- Self-describing formats — JSON, YAML, RON (Rusty Object Notation) — deserialize unchanged.
+- Self-describing formats deserialize unchanged: JSON, YAML, TOML, RON (Rusty Object Notation), map-encoded MessagePack.
 - Positional binary formats (`bincode`, `postcard`) hit end-of-input before the new fields. `#[serde(default)]` cannot rescue those; re-serialize from 0.5.x.
 
 Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ What `apply_stdp` does each step:
 
 Both new fields are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector. So pre-0.6 checkpoints still load, with one exception:
 
-- Self-describing formats deserialize unchanged: JSON, YAML, TOML, RON (Rusty Object Notation), map-encoded MessagePack.
+- Self-describing formats deserialize unchanged: JSON, YAML, TOML (Tom's Obvious Minimal Language), RON (Rusty Object Notation), map-encoded MessagePack.
 - Positional binary formats (`bincode`, `postcard`) hit end-of-input before the new fields. `#[serde(default)]` cannot rescue those; re-serialize from 0.5.x.
 
 Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ What `apply_stdp` does each step:
 - Accumulates a coincidence *only on the step a spike occurs*. Post fired now → `Δt ≥ 0`, potentiation. Pre fired now after an earlier post → `Δt < 0`, depression.
 - Converts traces to weights only when dopamine is present: `w += reward_lr · dopamine_lr · trace`.
 
-Both new fields are `#[serde(default)]`. `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints still load. Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
+Both new fields are `#[serde(default)]`. `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints load from self-describing formats (JSON, YAML, RON). Positional binary formats (`bincode`, `postcard`) hit end-of-input before the new fields, so `#[serde(default)]` cannot rescue those — re-serialize from 0.5.x. Rationale: [docs/adr/002-wire-eligibility-traces.md](docs/adr/002-wire-eligibility-traces.md).
 
 ### Neuromodulators are domain-agnostic by design
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neuromod"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "criterion",
  "rand",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ rand = "0.10.1"
 
 [dev-dependencies]
 criterion = "0.8.2"
+# Backward-compatibility tests deserialize pre-0.6 checkpoints that predate the
+# `eligibility` / `stdp_config` fields. Already in the tree via criterion.
+serde_json = "1.0"
 
 [[bench]]
 name = "neuron_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neuromod"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Biologically grounded spiking neural network (SNN) primitives in Rust: a topolog
 - Neutral initialization (blank synaptic weights; no hardcoded domain topology)
 - Generic neuromodulators: dopamine, serotonin, acetylcholine, norepinephrine
 - `GenericReward` trait for domain-specific reward shaping in downstream crates
-- Classical Hebbian STDP utilities and reward-modulated STDP types (`EligibilityTrace`, `RmStdpConfig`)
+- Reward-modulated STDP wired into the engine: per-synapse `EligibilityTrace` accumulation with a dopamine-gated payout, tuned by `RmStdpConfig`
+- Classical (unmodulated) Hebbian STDP utilities for the biological root case
 
 ### Engine (`SpikingNetwork`)
 
@@ -146,6 +147,55 @@ fn main() {
 
 For legacy hardware-calibrated signal mapping, use `SignalProfile::hardware_calibrated()`.
 
+## Reward-Modulated STDP
+
+`SpikingNetwork` learns *through* eligibility traces, not around them. Each `LifNeuron`
+carries one `EligibilityTrace` per input channel, indexed like `weights`:
+
+1. Every step, each trace decays and — on the step a spike actually occurs — accumulates the
+   pre/post timing kernel. This happens **whether or not dopamine is present**.
+2. Dopamine gates only the payout: `w += reward_lr × dopamine_lr × trace`, clamped to the
+   `RmStdpConfig` bounds.
+
+Splitting it that way is what buys credit assignment: reward can arrive several steps after
+the coincidence it pays for, and still find the credit waiting.
+
+```rust
+use neuromod::{NeuroModulators, RmStdpConfig, SpikingNetwork};
+
+fn main() {
+    let mut network = SpikingNetwork::with_dimensions(4, 1, 4);
+    for neuron in &mut network.neurons {
+        neuron.weights = vec![0.5; 4]; // sums to the engine's L1 weight budget
+    }
+
+    // Bank coincidences with reward switched off: traces grow, weights do not.
+    let unrewarded = NeuroModulators::default();
+    let stimuli = [1.0, 1.0, 0.0, 0.0];
+    for _ in 0..10 {
+        network.step(&stimuli, &unrewarded).unwrap();
+    }
+    println!("trace: {:.4}", network.neurons[0].eligibility[0].value); // > 0
+    println!("weight: {:.4}", network.neurons[0].weights[0]); // still 0.5
+
+    // Reward converts the banked trace into a weight change.
+    let rewarded = NeuroModulators { dopamine: 0.9, ..Default::default() };
+    for _ in 0..10 {
+        network.step(&stimuli, &rewarded).unwrap();
+    }
+    println!("weight: {:.4}", network.neurons[0].weights[0]); // driven synapse potentiated
+
+    // Retune decay, payout rate, and weight bounds at any time.
+    network.set_rm_stdp_config(RmStdpConfig { tau_eligibility: 100.0, ..Default::default() });
+}
+```
+
+Proof, not promise: the behavior above is covered by unit and multi-step tests in
+`src/rm_stdp.rs` and `src/engine.rs` (including a pre-0.6 checkpoint that deserializes
+without the trace fields and keeps stepping), and `cargo run --example rstdp_demo` prints
+the real trace and weight numbers. Rationale for wiring the types in rather than demoting
+them: [ADR 002](docs/adr/002-wire-eligibility-traces.md).
+
 ## Included Components
 
 - Engine: `SpikingNetwork`, `StepError` (LIF + Izhikevich banks)
@@ -153,8 +203,9 @@ For legacy hardware-calibrated signal mapping, use `SignalProfile::hardware_cali
 - Engine neuron types: `LifNeuron`, `IzhikevichNeuron`
 - Standalone neuron types: `GifNeuron`, `LapicqueNeuron`, `FitzHughNagumoNeuron`, `HodgkinHuxleyNeuron`
 - Learning/plasticity:
-  - Classical: `apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`
-  - Reward-modulated building blocks: `EligibilityTrace`, `RmStdpConfig`
+  - Classical (unmodulated): `apply_classical_stdp`, `StdpParams`, `HebbianIzhikevichNetwork`
+  - Reward-modulated, wired into `SpikingNetwork`: `EligibilityTrace`, `RmStdpConfig`,
+    `LifNeuron::eligibility`, `SpikingNetwork::set_rm_stdp_config`
 
 ## Architecture & Boundaries
 
@@ -165,6 +216,7 @@ See the full planning documents:
 - [Org Modularization Standards](docs/org-modularization.md) — workstream index (#35–#43), cross-cutting git/build/beads standards, and audit commands.
 - [neuromod Boundary Matrix](docs/neuromod-boundary-matrix.md) — runtime/deployment role, owns/does-not-own, allowed/forbidden dependencies vs. limbic-critic, brainstem-daemon, axon-encoder, synaptic-mesh, silicon-bridge, Spikenaut-Hardware, plasticity-lab, etc. (LIM-9).
 - [ADR 001: Shared traits live in neuromod](docs/adr/001-traits-in-neuromod.md) — why traits are hosted here.
+- [ADR 002: Wire eligibility traces into the engine](docs/adr/002-wire-eligibility-traces.md) — why R-STDP is wired rather than demoted, and what changed in the learning path.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,52 @@ without the trace fields and keeps stepping), and `cargo run --example rstdp_dem
 the real trace and weight numbers. Rationale for wiring the types in rather than demoting
 them: [ADR 002](docs/adr/002-wire-eligibility-traces.md).
 
+## Migration Notes
+
+### Unreleased (targets 0.6.0) — eligibility traces wired into the engine
+
+**Serialized state is unaffected.** `LifNeuron::eligibility` and
+`SpikingNetwork::stdp_config` are `#[serde(default)]`, and `apply_stdp` resizes a missing
+trace vector, so checkpoints written by 0.5.x still deserialize and step.
+
+**Struct literals need updating.** Both types have public fields and are not
+`#[non_exhaustive]`, so adding a field is a source-level break: any downstream
+`LifNeuron { .. }` or `SpikingNetwork { .. }` literal that spells out every field now fails
+to compile. Fill the remainder from the constructor or `Default`:
+
+```rust
+use neuromod::LifNeuron;
+
+// Before (0.5.x) — breaks in 0.6
+// let neuron = LifNeuron {
+//     membrane_potential: 0.0,
+//     decay_rate: 0.15,
+//     threshold: 0.02,
+//     base_threshold: 0.02,
+//     last_spike: false,
+//     weights: vec![0.0; 16],
+//     last_spike_time: -1,
+// };
+
+// After — forward-compatible with future field additions
+let neuron = LifNeuron {
+    weights: vec![0.0; 16],
+    ..LifNeuron::new()
+};
+```
+
+Callers that already build through `LifNeuron::new()`, `SpikingNetwork::new()`, or
+`SpikingNetwork::with_dimensions(..)` need no change.
+
+**Weight trajectories change.** Updates now flow through a decaying eligibility trace
+instead of being recomputed from raw spike times each step, so a 0.6 run will not reproduce
+0.5.x weights on the same inputs. Learning gained memory: reward arriving after a
+coincidence still pays for it.
+
+**Weight bounds moved into `RmStdpConfig`.** `RM_STDP_W_MIN` / `RM_STDP_W_MAX` remain public
+and are the defaults. Bounds take precedence over the engine's L1 weight budget, so
+narrowing them leaves each neuron's weight sum below budget by however much they bind.
+
 ## Included Components
 
 - Engine: `SpikingNetwork`, `StepError` (LIF + Izhikevich banks)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ CI installs the same toolchain on each OS. Keep `Cargo.toml` `rust-version`, `ru
 
 ```toml
 [dependencies]
-neuromod = "0.5.2"
+neuromod = "0.6.0"
 ```
+
+> `0.6.0` reaches crates.io when its tag lands. Until then the newest published release is
+> `0.5.2`, which predates the wired R-STDP API below — depend on the git repository if you
+> need it before the release.
 
 Links: [crates.io](https://crates.io/crates/neuromod) · [docs.rs](https://docs.rs/neuromod) · [repository](https://github.com/Limen-Neural/neuromod)
 
@@ -149,11 +153,10 @@ For legacy hardware-calibrated signal mapping, use `SignalProfile::hardware_cali
 
 ## Reward-Modulated STDP
 
-> **Not in the pinned release.** `EligibilityTrace`, `RmStdpConfig`,
-> `SpikingNetwork::set_rm_stdp_config`, and `LifNeuron::eligibility` are unreleased; the
-> Installation pin above (`0.5.2`) does not carry them, and the code below will not compile
-> against it. They arrive in 0.6.0 — see [Migration Notes](#migration-notes), or depend on the
-> git branch until then.
+> **New in 0.6.0.** `EligibilityTrace`, `RmStdpConfig`, `SpikingNetwork::set_rm_stdp_config`,
+> and `LifNeuron::eligibility` do not exist in `0.5.2`, so the code below will not compile
+> against the last published release — see [Installation](#installation) and
+> [Migration Notes](#migration-notes).
 
 `SpikingNetwork` learns *through* eligibility traces, not around them. Each `LifNeuron`
 carries one `EligibilityTrace` per input channel, indexed like `weights`:
@@ -204,7 +207,7 @@ them: [ADR 002](docs/adr/002-wire-eligibility-traces.md).
 
 ## Migration Notes
 
-### Unreleased (targets 0.6.0) — eligibility traces wired into the engine
+### 0.6.0 — eligibility traces wired into the engine
 
 **Serialized state survives in self-describing formats.** `LifNeuron::eligibility` and
 `SpikingNetwork::stdp_config` are `#[serde(default)]`, and `apply_stdp` resizes a missing
@@ -371,10 +374,10 @@ This repository uses a comprehensive CI setup for speed, quality, security, and 
   Pull (examples only — prefer the crates.io library for embedding):
 
   ```bash
-  docker pull ghcr.io/limen-neural/neuromod:0.5.2
+  docker pull ghcr.io/limen-neural/neuromod:0.6.0
   # or Docker Hub:
-  docker pull pelon23/neuromod:0.5.2
-  docker run --rm ghcr.io/limen-neural/neuromod:0.5.2 ls /usr/local/bin
+  docker pull pelon23/neuromod:0.6.0
+  docker run --rm ghcr.io/limen-neural/neuromod:0.6.0 ls /usr/local/bin
   ```
 
   Local usage:

--- a/README.md
+++ b/README.md
@@ -200,9 +200,17 @@ them: [ADR 002](docs/adr/002-wire-eligibility-traces.md).
 
 ### Unreleased (targets 0.6.0) — eligibility traces wired into the engine
 
-**Serialized state is unaffected.** `LifNeuron::eligibility` and
+**Serialized state survives in self-describing formats.** `LifNeuron::eligibility` and
 `SpikingNetwork::stdp_config` are `#[serde(default)]`, and `apply_stdp` resizes a missing
-trace vector, so checkpoints written by 0.5.x still deserialize and step.
+trace vector, so a 0.5.x checkpoint written with a format that names its fields — JSON,
+YAML, TOML, RON, map-encoded MessagePack — still deserializes and steps. This is covered by
+`test_pre_0_6_state_without_new_fields_loads_and_steps`, which strips both fields from
+serialized JSON and drives the restored network.
+
+`#[serde(default)]` cannot help positional binary formats such as `bincode` or `postcard`:
+they encode a struct as a bare sequence of fields, so old bytes hit end-of-input before the
+new fields are reached. If you checkpoint with one of those, re-serialize from 0.5.x before
+upgrading, or read through a versioned wrapper of your own.
 
 **Struct literals need updating.** Both types have public fields and are not
 `#[non_exhaustive]`, so adding a field is a source-level break: any downstream

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ For legacy hardware-calibrated signal mapping, use `SignalProfile::hardware_cali
 
 ## Reward-Modulated STDP
 
+> **Not in the pinned release.** `EligibilityTrace`, `RmStdpConfig`,
+> `SpikingNetwork::set_rm_stdp_config`, and `LifNeuron::eligibility` are unreleased; the
+> Installation pin above (`0.5.2`) does not carry them, and the code below will not compile
+> against it. They arrive in 0.6.0 — see [Migration Notes](#migration-notes), or depend on the
+> git branch until then.
+
 `SpikingNetwork` learns *through* eligibility traces, not around them. Each `LifNeuron`
 carries one `EligibilityTrace` per input channel, indexed like `weights`:
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,11 @@ instead of being recomputed from raw spike times each step, so a 0.6 run will no
 coincidence still pays for it.
 
 **Weight bounds moved into `RmStdpConfig`.** `RM_STDP_W_MIN` / `RM_STDP_W_MAX` remain public
-and are the defaults. Bounds take precedence over the engine's L1 weight budget, so
-narrowing them leaves each neuron's weight sum below budget by however much they bind.
+and are the defaults. Bounds take precedence over the engine's L1 weight budget: `step`
+scales toward the budget and then clamps, so a binding bound leaves the sum **off** budget in
+whichever direction it binds — a lowered `w_max` caps weights and leaves the sum short, while
+a raised `w_min` lifts weights after scaling and can push the sum past it. The defaults cannot
+bind, so the budget holds exactly under them.
 
 ## Included Components
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -140,12 +140,14 @@ quietly reverts to an inline rule and leaves the eligibility types decorative:
 
 Chained with `&&` so the block exits non-zero on the **first** missing invariant. Run as
 separate commands, an early failure would be masked by a later success and the guard would
-report a pass on a half-unwired engine.
+report a pass on a half-unwired engine. Decay and accumulation are checked separately rather
+than as one alternation, so dropping either one fails the guard.
 
 ```bash
 grep -q 'pub eligibility: Vec<EligibilityTrace>' src/lif.rs \
   && grep -q 'pub stdp_config: RmStdpConfig' src/engine.rs \
-  && grep -qE 'trace\.decay\(\)|trace\.accumulate\(' src/engine.rs \
+  && grep -q 'trace.decay()' src/engine.rs \
+  && grep -q 'trace.accumulate(' src/engine.rs \
   && grep -q 'pub fn set_rm_stdp_config' src/engine.rs \
   && echo "ok: R-STDP still wired into the engine"
 ```

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -134,6 +134,17 @@ grep -R 'pub fn apply_classical_stdp\|pub fn apply_neuromodulation' src/
 grep -R 'pub struct EligibilityTrace\|pub struct RmStdpConfig' src/
 ```
 
+R-STDP must stay **wired into the engine**, not merely exported (GH#72; see
+[ADR 002](docs/adr/002-wire-eligibility-traces.md)). These guard against a refactor that
+quietly reverts to an inline rule and leaves the eligibility types decorative:
+
+```bash
+grep -n 'pub eligibility: Vec<EligibilityTrace>' src/lif.rs
+grep -n 'pub stdp_config: RmStdpConfig' src/engine.rs
+grep -n 'trace.decay()\|trace.accumulate(' src/engine.rs
+grep -n 'pub fn set_rm_stdp_config' src/engine.rs
+```
+
 Verify Criterion benchmarks aren't silently reverted to the default libtest harness (causes `cargo bench` to report `running 0 tests` instead of executing benchmarks). Every `[[bench]]` must explicitly set `harness = false` — omitting the key is as bad as setting `true`:
 
 ```bash

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -138,11 +138,16 @@ R-STDP must stay **wired into the engine**, not merely exported (GH#72; see
 [ADR 002](docs/adr/002-wire-eligibility-traces.md)). These guard against a refactor that
 quietly reverts to an inline rule and leaves the eligibility types decorative:
 
+Chained with `&&` so the block exits non-zero on the **first** missing invariant. Run as
+separate commands, an early failure would be masked by a later success and the guard would
+report a pass on a half-unwired engine.
+
 ```bash
-grep -n 'pub eligibility: Vec<EligibilityTrace>' src/lif.rs
-grep -n 'pub stdp_config: RmStdpConfig' src/engine.rs
-grep -n 'trace.decay()\|trace.accumulate(' src/engine.rs
-grep -n 'pub fn set_rm_stdp_config' src/engine.rs
+grep -q 'pub eligibility: Vec<EligibilityTrace>' src/lif.rs \
+  && grep -q 'pub stdp_config: RmStdpConfig' src/engine.rs \
+  && grep -qE 'trace\.decay\(\)|trace\.accumulate\(' src/engine.rs \
+  && grep -q 'pub fn set_rm_stdp_config' src/engine.rs \
+  && echo "ok: R-STDP still wired into the engine"
 ```
 
 Verify Criterion benchmarks aren't silently reverted to the default libtest harness (causes `cargo bench` to report `running 0 tests` instead of executing benchmarks). Every `[[bench]]` must explicitly set `harness = false` — omitting the key is as bad as setting `true`:

--- a/benches/README.md
+++ b/benches/README.md
@@ -58,6 +58,10 @@ Benchmarks synaptic plasticity operations:
 - `classical_stdp_ltp` - Classical STDP with pre-before-post timing (LTP)
 - `classical_stdp_ltd` - Classical STDP with post-before-pre timing (LTD)
 - `eligibility_trace_decay` - Eligibility trace decay operation
+- `eligibility_trace_accumulate_ltp` - Kernel evaluation and accumulation for a pre-before-post pair
+- `eligibility_trace_accumulate_ltd` - Same for post-before-pre (depression)
+- `rm_stdp_trace_to_weight` - One synapse's decay -> accumulate -> dopamine-gated conversion
+- `engine_step/unrewarded` / `engine_step/rewarded` - Full `SpikingNetwork::step` (64 LIF over 64 channels) carrying trace bookkeeping, with the dopamine gate shut and open
 - `stdp_weight_update` - Complete weight update cycle
 - `hebbian_network_update` - Hebbian network weight update
 - `stdp_delta_t_calculation` - Spike timing difference calculation

--- a/benches/stdp_bench.rs
+++ b/benches/stdp_bench.rs
@@ -51,6 +51,10 @@ fn bench_eligibility_trace_accumulate(c: &mut Criterion) {
         let mut trace = EligibilityTrace::new(50.0);
         b.iter(|| {
             trace.accumulate(black_box(5.0));
+            // Observe the result: `accumulate` only writes `self.value`, so
+            // without this the kernel and the add are dead stores and the
+            // bench times an empty loop.
+            black_box(trace.value);
             trace.value = 0.0;
         });
     });
@@ -59,6 +63,7 @@ fn bench_eligibility_trace_accumulate(c: &mut Criterion) {
         let mut trace = EligibilityTrace::new(50.0);
         b.iter(|| {
             trace.accumulate(black_box(-5.0));
+            black_box(trace.value);
             trace.value = 0.0;
         });
     });

--- a/benches/stdp_bench.rs
+++ b/benches/stdp_bench.rs
@@ -1,8 +1,11 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use neuromod::rm_stdp::{
     EligibilityTrace, RM_STDP_A_MINUS, RM_STDP_A_PLUS, RM_STDP_TAU_MINUS, RM_STDP_TAU_PLUS,
+    RmStdpConfig,
 };
-use neuromod::{HebbianIzhikevichNetwork, StdpParams, apply_classical_stdp};
+use neuromod::{
+    HebbianIzhikevichNetwork, NeuroModulators, SpikingNetwork, StdpParams, apply_classical_stdp,
+};
 use std::hint::black_box;
 
 fn bench_classical_stdp(c: &mut Criterion) {
@@ -41,6 +44,68 @@ fn bench_eligibility_trace_decay(c: &mut Criterion) {
             trace.decay();
         });
     });
+}
+
+fn bench_eligibility_trace_accumulate(c: &mut Criterion) {
+    c.bench_function("eligibility_trace_accumulate_ltp", |b| {
+        let mut trace = EligibilityTrace::new(50.0);
+        b.iter(|| {
+            trace.accumulate(black_box(5.0));
+            trace.value = 0.0;
+        });
+    });
+
+    c.bench_function("eligibility_trace_accumulate_ltd", |b| {
+        let mut trace = EligibilityTrace::new(50.0);
+        b.iter(|| {
+            trace.accumulate(black_box(-5.0));
+            trace.value = 0.0;
+        });
+    });
+}
+
+/// The wired path: decay, accumulate, then convert the trace into a weight
+/// change under the dopamine gate — one synapse's worth of `apply_stdp`.
+fn bench_reward_conversion(c: &mut Criterion) {
+    let config = RmStdpConfig::default();
+
+    c.bench_function("rm_stdp_trace_to_weight", |b| {
+        let mut trace = EligibilityTrace::new(config.tau_eligibility);
+        let mut weight = 0.5_f32;
+        b.iter(|| {
+            trace.decay();
+            trace.accumulate(black_box(1.0));
+            let dw = config.reward_lr * black_box(0.45_f32) * trace.value;
+            weight = (weight + dw).clamp(config.w_min, config.w_max);
+            black_box(weight);
+        });
+    });
+}
+
+/// End-to-end engine step, which now carries trace bookkeeping for every
+/// synapse. Rewarded and unrewarded are separate: only the rewarded path pays
+/// for the trace -> weight conversion.
+fn bench_engine_step_with_traces(c: &mut Criterion) {
+    let mut group = c.benchmark_group("engine_step");
+
+    for (label, dopamine) in [("unrewarded", 0.0_f32), ("rewarded", 0.9)] {
+        group.bench_function(label, |b| {
+            let mut network = SpikingNetwork::with_dimensions(64, 5, 64);
+            for neuron in &mut network.neurons {
+                neuron.weights = vec![2.0 / 64.0; 64];
+            }
+            let modulators = NeuroModulators {
+                dopamine,
+                ..Default::default()
+            };
+            let stimuli = vec![0.5_f32; 64];
+            b.iter(|| {
+                let _ = network.step(black_box(&stimuli), black_box(&modulators));
+            });
+        });
+    }
+
+    group.finish();
 }
 
 fn bench_stdp_weight_update(c: &mut Criterion) {
@@ -118,6 +183,9 @@ criterion_group!(
     benches,
     bench_classical_stdp,
     bench_eligibility_trace_decay,
+    bench_eligibility_trace_accumulate,
+    bench_reward_conversion,
+    bench_engine_step_with_traces,
     bench_stdp_weight_update,
     bench_hebbian_network_update,
     bench_stdp_delta_t_calculation,

--- a/benches/stdp_bench.rs
+++ b/benches/stdp_bench.rs
@@ -90,7 +90,17 @@ fn bench_reward_conversion(c: &mut Criterion) {
 /// End-to-end engine step, which now carries trace bookkeeping for every
 /// synapse. Rewarded and unrewarded are separate: only the rewarded path pays
 /// for the trace -> weight conversion.
+///
+/// The network is warmed to steady state before timing. `apply_stdp` skips both
+/// the decay `exp` and the weight conversion while a trace is still exactly
+/// zero, so a freshly built network makes the first samples cheaper than every
+/// later one — timing from a blank state would measure that transient rather
+/// than the per-step cost of a running network. Warming up is preferable to
+/// rebuilding per iteration here: `SpikingNetwork` is not `Clone`, and steady
+/// state is the condition worth reporting.
 fn bench_engine_step_with_traces(c: &mut Criterion) {
+    const WARMUP_STEPS: usize = 200; // >> tau_eligibility, so traces settle
+
     let mut group = c.benchmark_group("engine_step");
 
     for (label, dopamine) in [("unrewarded", 0.0_f32), ("rewarded", 0.9)] {
@@ -104,6 +114,11 @@ fn bench_engine_step_with_traces(c: &mut Criterion) {
                 ..Default::default()
             };
             let stimuli = vec![0.5_f32; 64];
+
+            for _ in 0..WARMUP_STEPS {
+                let _ = network.step(&stimuli, &modulators);
+            }
+
             b.iter(|| {
                 let _ = network.step(black_box(&stimuli), black_box(&modulators));
             });

--- a/benches/stdp_bench.rs
+++ b/benches/stdp_bench.rs
@@ -136,7 +136,10 @@ fn bench_engine_step_with_traces(c: &mut Criterion) {
             }
 
             b.iter(|| {
-                let _ = network.step(black_box(&stimuli), black_box(&modulators));
+                // Observe the returned spike list: `step` mutates `network`, but
+                // dropping its result lets the optimizer elide the work that
+                // builds that list.
+                black_box(network.step(black_box(&stimuli), black_box(&modulators)))
             });
         });
     }

--- a/benches/stdp_bench.rs
+++ b/benches/stdp_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use neuromod::rm_stdp::{
     EligibilityTrace, RM_STDP_A_MINUS, RM_STDP_A_PLUS, RM_STDP_TAU_MINUS, RM_STDP_TAU_PLUS,
     RmStdpConfig,
@@ -71,19 +71,35 @@ fn bench_eligibility_trace_accumulate(c: &mut Criterion) {
 
 /// The wired path: decay, accumulate, then convert the trace into a weight
 /// change under the dopamine gate — one synapse's worth of `apply_stdp`.
+///
+/// Batched rather than carried across iterations. Every conversion here is a
+/// potentiation, so a persistent `weight` climbs to `w_max` within a couple of
+/// hundred iterations and stays pinned: from then on `clamp` returns the bound
+/// and the bench times a saturated synapse instead of a converting one. Each
+/// sample starts from a mid-range weight and a representative banked trace, so
+/// the measured work is the same on the first sample and the last.
 fn bench_reward_conversion(c: &mut Criterion) {
     let config = RmStdpConfig::default();
 
     c.bench_function("rm_stdp_trace_to_weight", |b| {
-        let mut trace = EligibilityTrace::new(config.tau_eligibility);
-        let mut weight = 0.5_f32;
-        b.iter(|| {
-            trace.decay();
-            trace.accumulate(black_box(1.0));
-            let dw = config.reward_lr * black_box(0.45_f32) * trace.value;
-            weight = (weight + dw).clamp(config.w_min, config.w_max);
-            black_box(weight);
-        });
+        b.iter_batched(
+            || {
+                (
+                    EligibilityTrace {
+                        value: 0.5,
+                        tau: config.tau_eligibility,
+                    },
+                    0.5_f32,
+                )
+            },
+            |(mut trace, weight)| {
+                trace.decay();
+                trace.accumulate(black_box(1.0));
+                let dw = config.reward_lr * black_box(0.45_f32) * trace.value;
+                (weight + dw).clamp(config.w_min, config.w_max)
+            },
+            BatchSize::SmallInput,
+        );
     });
 }
 

--- a/docs/adr/002-wire-eligibility-traces.md
+++ b/docs/adr/002-wire-eligibility-traces.md
@@ -33,8 +33,12 @@ experimental.
   constant, the reward learning rate, and the weight bounds.
 - `SpikingNetwork::apply_stdp` decays and accumulates traces **every step, independent of
   dopamine**, and gates only the trace → weight conversion on dopamine.
-- Both new fields are `#[serde(default)]`, so pre-0.6 checkpoints still deserialize; the
-  engine resizes a missing or stale trace vector to match `weights` before use.
+- Both new fields are `#[serde(default)]`, so a pre-0.6 checkpoint written in a
+  self-describing format (JSON, YAML, RON, map-encoded MessagePack) still deserializes; the
+  engine resizes a missing or stale trace vector to match `weights` before use. Positional
+  binary formats such as `bincode` and `postcard` encode a struct as a bare sequence, so old
+  bytes reach end-of-input before the new fields and `#[serde(default)]` never applies —
+  those checkpoints must be re-serialized from 0.5.x. See the README migration notes.
 
 Trace accumulation is **event-gated**: a coincidence is recorded only on the step where the
 post neuron or the pre channel actually spiked, never re-recorded from a stale pair on

--- a/docs/adr/002-wire-eligibility-traces.md
+++ b/docs/adr/002-wire-eligibility-traces.md
@@ -1,0 +1,91 @@
+# ADR 002: Wire eligibility traces into the engine (do not demote)
+
+**Status:** Accepted
+
+**Date:** 2026-08-29
+
+## Context
+
+`neuromod` shipped `EligibilityTrace` and `RmStdpConfig` as public reward-modulated STDP
+(R-STDP) types, and the README listed them under "reward-modulated STDP types". Neither type
+was consumed by the live learning path: `SpikingNetwork::apply_stdp` recomputed a
+spike-timing kernel inline and wrote the result straight into `LifNeuron::weights`. The
+eligibility half of R-STDP — accumulate a trace of recent pre/post coincidences, then let a
+reward signal convert that trace into a weight change — existed only as an unused building
+block.
+
+That is the honesty gap tracked by GH#72 (epic), GH#73 (wire or demote), and GH#74 (prove it
+with tests): the public surface promised R-STDP, the engine delivered dopamine-gated direct
+STDP. Every source doc that disclosed the gap (`src/rm_stdp.rs`, `src/engine.rs`,
+`src/lib.rs`, `CLAUDE.md`) had to repeat the caveat, and downstream crates could not tell
+which half was real without reading the engine.
+
+Two ways to close it: make the promise true, or shrink the promise.
+
+## Decision
+
+Wire `EligibilityTrace` and `RmStdpConfig` into the live engine path. Do not demote them to
+experimental.
+
+- `LifNeuron` gains `eligibility: Vec<EligibilityTrace>`, one trace per input channel,
+  indexed exactly like `weights`.
+- `SpikingNetwork` gains an `stdp_config: RmStdpConfig` field holding the trace time
+  constant, the reward learning rate, and the weight bounds.
+- `SpikingNetwork::apply_stdp` decays and accumulates traces **every step, independent of
+  dopamine**, and gates only the trace → weight conversion on dopamine.
+- Both new fields are `#[serde(default)]`, so pre-0.6 checkpoints still deserialize; the
+  engine resizes a missing or stale trace vector to match `weights` before use.
+
+Trace accumulation is **event-gated**: a coincidence is recorded only on the step where the
+post neuron or the pre channel actually spiked, never re-recorded from a stale pair on
+subsequent steps. A single spike pair therefore leaves a single decaying imprint, which is
+what an eligibility trace means. Re-applying the kernel every step from persistent
+`last_spike_time` values would inflate the trace to roughly `tau x kernel` for a pair that
+fired once — learning that looks real but is an artifact of the loop, exactly the "silent
+no-op that looks like learning" GH#73 rules out.
+
+## Consequences
+
+- **Behavior change (breaking).** Weight updates now flow through a decaying trace instead of
+  being recomputed from raw spike times each step. Same-input runs will not reproduce pre-0.6
+  weight trajectories. Pre-1.0 policy bumps the minor version (`0.5.x` -> `0.6.0`).
+- Learning has memory. A coincidence that happened while dopamine was zero can still be
+  converted into a weight change several steps later when reward arrives — the credit
+  assignment R-STDP exists to provide, and the reason dopamine no longer short-circuits the
+  whole plasticity pass.
+- `apply_stdp` now runs every step rather than early-returning when dopamine is ~0. Traces
+  that are still exactly zero skip both decay and conversion, so a blank or unrewarded
+  network stays cheap.
+- Weight bounds come from `stdp_config` rather than the `RM_STDP_W_MIN` / `RM_STDP_W_MAX`
+  constants directly, in `apply_stdp` and in the L1 renormalization pass. The constants
+  remain public and are the config defaults.
+- `stdp_config` is a public field like every other field on `SpikingNetwork`. Assigning it
+  directly does not re-`tau` traces that already exist, so
+  `SpikingNetwork::set_rm_stdp_config` is provided to keep the two consistent.
+- Docs no longer carry the "not yet wired" caveat, and the R-STDP claim is backed by tests
+  (`src/rm_stdp.rs`, `src/engine.rs`) and by `examples/rstdp_demo.rs`, which prints real
+  trace and weight numbers instead of narrating them.
+
+## Alternatives Considered
+
+- **Demote to experimental** (`#[doc(hidden)]`, feature gate, or move to an `experimental`
+  module) — Rejected. It closes the honesty gap by deleting the feature rather than
+  delivering it, and the v0.6 milestone is "product completeness". The types are small, the
+  wiring is contained in one private method, and reward-modulated plasticity is the point of
+  a crate named `neuromod`.
+- **Keep the inline rule and consume traces in parallel** (traces updated but not driving
+  weights) — Rejected. That is the current state with extra bookkeeping: two plasticity
+  stories, one of them decorative.
+- **Accumulate the kernel every step from `last_spike_time`** (the mechanically simpler
+  wiring) — Rejected for the inflation reason above.
+- **Add `RmStdpConfig` as a `with_dimensions` parameter** — Rejected. It breaks every
+  existing call site for a value that has a sane default; `set_rm_stdp_config` is additive.
+
+## References
+
+- Epic: #72 (close the R-STDP / eligibility gap)
+- Children: #73 (wire or demote), #74 (test the reward-gated path)
+- Milestone: neuromod v0.6 — Product completeness
+- Implementation: `src/rm_stdp.rs`, `src/lif.rs`, `src/engine.rs`
+- Proof: unit and multi-step tests in `src/rm_stdp.rs` and `src/engine.rs`; `examples/rstdp_demo.rs`
+- Prior art on the split between engine and standalone building blocks: `docs/adr/001-traits-in-neuromod.md`

--- a/docs/adr/002-wire-eligibility-traces.md
+++ b/docs/adr/002-wire-eligibility-traces.md
@@ -34,8 +34,8 @@ experimental.
 - `SpikingNetwork::apply_stdp` decays and accumulates traces **every step, independent of
   dopamine**, and gates only the trace → weight conversion on dopamine.
 - Both new fields are `#[serde(default)]`, so a pre-0.6 checkpoint written in a
-  self-describing format (JSON, YAML, RON, map-encoded MessagePack) still deserializes; the
-  engine resizes a missing or stale trace vector to match `weights` before use. Positional
+  self-describing format (JSON, YAML, TOML, RON, map-encoded MessagePack) still deserializes;
+  the engine resizes a missing or stale trace vector to match `weights` before use. Positional
   binary formats such as `bincode` and `postcard` encode a struct as a bare sequence, so old
   bytes reach end-of-input before the new fields and `#[serde(default)]` never applies —
   those checkpoints must be re-serialized from 0.5.x. See the README migration notes.

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -220,7 +220,16 @@ fn scenario_slow_traces(network: &mut SpikingNetwork) {
     }
     report(network, "slow config");
     report(&default_twin, "default config");
+    explain_slow_vs_default(network, &default_twin, entry_weight);
+}
 
+/// Decompose the A/B above: which knob accounts for how much of the weight-gain
+/// gap, and where the two traces ended up.
+fn explain_slow_vs_default(
+    network: &SpikingNetwork,
+    default_twin: &SpikingNetwork,
+    entry_weight: f32,
+) {
     let slow_gain = network.neurons[0].weights[0] - entry_weight;
     let default_gain = default_twin.neurons[0].weights[0] - entry_weight;
     // Fraction of a trace discarded per step, read off each network's live tau.

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -78,10 +78,10 @@ fn scenario_no_reward(network: &mut SpikingNetwork, config: &RmStdpConfig, seed:
     }
     report(network, "after 10 steps");
     println!(
-        "  Weights held at {seed:.4}: the dopamine gate is shut. The driven\n  \
-         synapses still banked eligibility (e > 0) — that credit stays claimable\n  \
-         for roughly {:.0} steps.\n",
-        config.tau_eligibility
+        "  Weights held at {:.4}, still the {seed:.4} they were seeded with: the\n  \
+         dopamine gate is shut. The driven synapses did bank eligibility (e > 0)\n  \
+         — that credit stays claimable for roughly {:.0} steps.\n",
+        network.neurons[0].weights[0], config.tau_eligibility
     );
 }
 

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -162,19 +162,66 @@ fn main() {
     );
 
     println!("--- Scenario 5: Slower Traces via `RmStdpConfig` ---");
+    // Snapshot the network before touching its config. The twin inherits this
+    // exact state and keeps the defaults, then sees the identical stimuli and
+    // modulators below — so the only thing separating the two runs is
+    // `RmStdpConfig`. `SpikingNetwork` is not `Clone`, but it is serde
+    // round-trippable, which is the same mechanism used for checkpointing.
+    let mut default_twin: SpikingNetwork =
+        serde_json::from_str(&serde_json::to_string(&network).expect("network must serialize"))
+            .expect("snapshot must deserialize");
+
+    let entry_weight = network.neurons[0].weights[0];
+    let entry_trace = network.neurons[0].eligibility[0].value;
+
     network.set_rm_stdp_config(RmStdpConfig {
         tau_eligibility: 200.0,
         reward_lr: 0.02,
         ..RmStdpConfig::default()
     });
     println!(
-        "  tau_eligibility -> {:.1}, reward_lr -> {:.3}",
-        network.stdp_config.tau_eligibility, network.stdp_config.reward_lr
+        "  tau_eligibility {:.1} -> {:.1}, reward_lr {:.3} -> {:.3}",
+        default_twin.stdp_config.tau_eligibility,
+        network.stdp_config.tau_eligibility,
+        default_twin.stdp_config.reward_lr,
+        network.stdp_config.reward_lr
     );
     println!(
-        "  Traces now hold credit ~4x longer and pay out more slowly; existing\n  \
-         traces keep their accumulated value and adopt the new tau: {:.1}\n",
-        network.neurons[0].eligibility[0].tau
+        "  ch0 trace across the switch: {entry_trace:+.4} -> {:+.4} (kept), now\n  \
+         decaying with tau={:.1}\n",
+        network.neurons[0].eligibility[0].value, network.neurons[0].eligibility[0].tau
+    );
+
+    // Same 10 rewarded steps Scenario 2 used, run on both networks.
+    for _ in 0..10 {
+        network
+            .step(&STIMULI, &rewarded)
+            .expect("stimuli length must match network channels");
+        default_twin
+            .step(&STIMULI, &rewarded)
+            .expect("stimuli length must match network channels");
+    }
+    report(&network, "slow config");
+    report(&default_twin, "default config");
+
+    let slow_gain = network.neurons[0].weights[0] - entry_weight;
+    let default_gain = default_twin.neurons[0].weights[0] - entry_weight;
+    // Fraction of a trace discarded per step, read off each network's live tau.
+    let per_step_loss = |tau: f32| 100.0 * (1.0 - (-1.0 / tau).exp());
+    println!(
+        "  Over those 10 steps ch0 gained {slow_gain:+.4} under the slow config \
+         against\n  {default_gain:+.4} under the defaults — {:.2}x the payout, \
+         because `reward_lr` scales\n  every conversion. The trace itself ran \
+         the other way: {:+.4} against\n  {:+.4}, since the longer tau discards \
+         {:.2}% of it per step instead of\n  {:.2}%. That 4x is the decay \
+         constant, not the trace value — both networks\n  are still taking in \
+         fresh coincidences every step, so the gap compounds rather\n  \
+         than arriving at 4x.\n",
+        slow_gain / default_gain,
+        network.neurons[0].eligibility[0].value,
+        default_twin.neurons[0].eligibility[0].value,
+        per_step_loss(network.stdp_config.tau_eligibility),
+        per_step_loss(default_twin.stdp_config.tau_eligibility),
     );
 
     println!("=== Modulator Operations Demo ===\n");

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -227,14 +227,18 @@ fn scenario_slow_traces(network: &mut SpikingNetwork) {
     let per_step_loss = |tau: f32| 100.0 * (1.0 - (-1.0 / tau).exp());
     println!(
         "  Over those 10 steps ch0 gained {slow_gain:+.4} under the slow config \
-         against\n  {default_gain:+.4} under the defaults — {:.2}x the payout, \
-         because `reward_lr` scales\n  every conversion. The trace itself ran \
-         the other way: {:+.4} against\n  {:+.4}, since the longer tau discards \
-         {:.2}% of it per step instead of\n  {:.2}%. That 4x is the decay \
-         constant, not the trace value — both networks\n  are still taking in \
-         fresh coincidences every step, so the gap compounds rather\n  \
-         than arriving at 4x.\n",
+         against\n  {default_gain:+.4} under the defaults: a net weight-gain \
+         ratio of {:.2}x. That is\n  an end-to-end figure, not a payout factor \
+         — both config changes and the L1\n  pass feed into it. `reward_lr` \
+         alone accounts for {:.2}x; the slow config's\n  larger trace pulls the \
+         other way.\n  \
+         That trace is {:+.4} against {:+.4}, since the longer tau discards \
+         {:.2}%\n  of it per step instead of {:.2}%. The 4x there is the ratio \
+         of decay\n  constants, not of trace values — both networks keep taking \
+         in fresh\n  coincidences every step, so the gap compounds rather than \
+         arriving at 4x.\n",
         slow_gain / default_gain,
+        network.stdp_config.reward_lr / default_twin.stdp_config.reward_lr,
         network.neurons[0].eligibility[0].value,
         default_twin.neurons[0].eligibility[0].value,
         per_step_loss(network.stdp_config.tau_eligibility),

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -1,125 +1,174 @@
 //! Reward-Modulated STDP (R-STDP) Demo
 //!
-//! Demonstrates reward-modulated spike-timing-dependent plasticity using
-//! `SpikingNetwork` and generic neuromodulators.
+//! Walks the wired reward-modulated plasticity path in `SpikingNetwork`:
+//! per-synapse eligibility traces accumulate spike-timing coincidences on
+//! every step, and dopamine converts those traces into weight changes.
+//!
+//! Every number below is read back out of the network after `step` — nothing
+//! here is narrated from a constant.
 //!
 //! Run with: cargo run --example rstdp_demo
 
-use neuromod::{NeuroModulators, Observation, SpikingNetwork, UnitReward};
+use neuromod::{NeuroModulators, Observation, RmStdpConfig, SpikingNetwork, UnitReward};
+
+/// Channels 0 and 1 fire on every step; channels 2 and 3 stay silent.
+const STIMULI: [f32; 4] = [1.0, 1.0, 0.0, 0.0];
+
+/// Print neuron 0's synaptic weights beside the eligibility traces that drive them.
+fn report(network: &SpikingNetwork, label: &str) {
+    let neuron = &network.neurons[0];
+    print!("  {label:<22}");
+    for ch in 0..network.num_channels {
+        print!(
+            " | ch{ch}: w={:.4} e={:+.4}",
+            neuron.weights[ch], neuron.eligibility[ch].value
+        );
+    }
+    println!();
+}
 
 fn main() {
     println!("=== Reward-Modulated STDP Demo ===\n");
 
-    let mut network = SpikingNetwork::new();
+    let mut network = SpikingNetwork::with_dimensions(4, 2, STIMULI.len());
 
+    // Seed every synapse at an equal share of the engine's L1 weight budget, so
+    // the renormalization pass starts neutral and any drift below is learning.
+    let seed = 2.0 / STIMULI.len() as f32;
+    for neuron in &mut network.neurons {
+        neuron.weights = vec![seed; STIMULI.len()];
+    }
+
+    let config = RmStdpConfig::default();
     println!("Network initialized:");
-    println!("  LIF neurons: {}", network.neurons.len());
+    println!("  LIF neurons:        {}", network.neurons.len());
     println!("  Izhikevich neurons: {}", network.iz_neurons.len());
-    println!("  Input channels: {}\n", 16);
-
-    let stimuli = [
-        0.5, 0.3, 0.8, 0.2, 0.1, 0.9, 0.4, 0.7, 0.6, 0.2, 0.8, 0.3, 0.5, 0.1, 0.9, 0.4,
-    ];
-
-    println!("Input stimuli (first 8 channels): {:?}", &stimuli[..8]);
-
-    let mut modulators = NeuroModulators::default();
-    println!("\nInitial modulators:");
-    println!("  Dopamine: {:.2} (reward signal)", modulators.dopamine);
+    println!("  Input channels:     {}", network.num_channels);
+    println!("  Seed weight:        {seed:.4} per synapse");
+    println!("\nR-STDP configuration (`RmStdpConfig::default()`):");
+    println!("  tau_eligibility: {:.1} steps", config.tau_eligibility);
+    println!("  reward_lr:       {:.3}", config.reward_lr);
     println!(
-        "  Norepinephrine: {:.2} (arousal/stress signal)",
-        modulators.norepinephrine
+        "  weight bounds:   [{:.1}, {:.1}]",
+        config.w_min, config.w_max
     );
-    println!(
-        "  Acetylcholine: {:.2} (focus signal)",
-        modulators.acetylcholine
-    );
-    println!(
-        "  Serotonin: {:.2} (stability signal)\n",
-        modulators.serotonin
-    );
+    println!("\nStimuli: {STIMULI:?}  (channels 0-1 driven, 2-3 silent)\n");
 
     println!("=== Simulation Scenarios ===\n");
 
-    println!("--- Scenario 1: No Reward (Baseline) ---");
-    modulators = NeuroModulators::default();
-    let spikes = network
-        .step(&stimuli, &modulators)
-        .expect("stimuli length must match network channels");
+    println!("--- Scenario 1: No Reward — credit is earned, not yet paid ---");
+    let no_reward = NeuroModulators::default();
+    println!("  dopamine={:.2}\n", no_reward.dopamine);
+    report(&network, "before");
+    for _ in 0..10 {
+        network
+            .step(&STIMULI, &no_reward)
+            .expect("stimuli length must match network channels");
+    }
+    report(&network, "after 10 steps");
     println!(
-        "  Modulators: dopamine={:.2}, norepinephrine={:.2}",
-        modulators.dopamine, modulators.norepinephrine
+        "  Weights held at {seed:.4}: the dopamine gate is shut. The driven\n  \
+         synapses still banked eligibility (e > 0) — that credit stays claimable\n  \
+         for roughly {:.0} steps.\n",
+        config.tau_eligibility
     );
-    println!("  Neurons spiked: {}", spikes.len());
-    println!("  STDP learning: DISABLED (no dopamine)\n");
 
-    println!("--- Scenario 2: Reward State (High Dopamine) ---");
-    modulators = NeuroModulators {
+    println!("--- Scenario 2: Reward State (High Dopamine) — the trace is cashed in ---");
+    let rewarded = NeuroModulators {
         dopamine: 0.9,
         norepinephrine: 0.1,
         acetylcholine: 0.7,
         ..Default::default()
     };
-    let spikes = network
-        .step(&stimuli, &modulators)
-        .expect("stimuli length must match network channels");
     println!(
-        "  Modulators: dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
-        modulators.dopamine, modulators.norepinephrine, modulators.acetylcholine
+        "  dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
+        rewarded.dopamine, rewarded.norepinephrine, rewarded.acetylcholine
     );
-    println!("  Neurons spiked: {}", spikes.len());
-    println!("  STDP learning: ENABLED (dopamine > 0.5)");
-    println!("  Learning rate: {:.3}", 0.5 * modulators.dopamine);
-
-    println!("  Sample weights (neuron 0, first 8 channels):");
-    for (ch, &w) in network.neurons[0].weights.iter().take(8).enumerate() {
-        println!("    Channel {}: {:.4}", ch, w);
+    println!("  learning rate: {:.3}\n", 0.5 * rewarded.dopamine);
+    let before = network.neurons[0].weights.clone();
+    for _ in 0..10 {
+        network
+            .step(&STIMULI, &rewarded)
+            .expect("stimuli length must match network channels");
+    }
+    report(&network, "after 10 steps");
+    print!("  Weight deltas:        ");
+    for (ch, (&now, &then)) in network.neurons[0]
+        .weights
+        .iter()
+        .zip(before.iter())
+        .enumerate()
+    {
+        print!(" | ch{ch}: {:+.4}", now - then);
     }
     println!();
+    println!(
+        "  Driven synapses potentiated; silent ones lost share of the fixed L1\n  \
+         budget. No hand-written rule ran here — the deltas are\n  \
+         reward_lr x dopamine_lr x eligibility.\n"
+    );
 
     println!("--- Scenario 3: Stress State (High Norepinephrine) ---");
-    modulators = NeuroModulators {
+    let stressed = NeuroModulators {
         dopamine: 0.2,
         norepinephrine: 0.8,
         acetylcholine: 0.3,
         ..Default::default()
     };
     let spikes = network
-        .step(&stimuli, &modulators)
+        .step(&STIMULI, &stressed)
         .expect("stimuli length must match network channels");
     println!(
-        "  Modulators: dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
-        modulators.dopamine, modulators.norepinephrine, modulators.acetylcholine
+        "  dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
+        stressed.dopamine, stressed.norepinephrine, stressed.acetylcholine
     );
     println!("  Neurons spiked: {}", spikes.len());
-    println!("  STDP learning: REDUCED (low dopamine)");
     println!(
-        "  Stress multiplier: {:.3} (1.0 - norepinephrine)",
-        (1.0 - modulators.norepinephrine).max(0.1)
+        "  Stress multiplier: {:.3} (1.0 - norepinephrine) — input drive is damped,\n  \
+         and the smaller learning rate slows the trace payout without stopping\n  \
+         accumulation.\n",
+        (1.0 - stressed.norepinephrine).max(0.1)
     );
-    println!();
 
     println!("--- Scenario 4: Focus State (High Acetylcholine) ---");
-    modulators = NeuroModulators {
+    let focused = NeuroModulators {
         dopamine: 0.6,
         norepinephrine: 0.1,
         acetylcholine: 0.9,
         serotonin: 0.5,
     };
     let spikes = network
-        .step(&stimuli, &modulators)
+        .step(&STIMULI, &focused)
         .expect("stimuli length must match network channels");
     println!(
-        "  Modulators: dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
-        modulators.dopamine, modulators.norepinephrine, modulators.acetylcholine
+        "  dopamine={:.2}, norepinephrine={:.2}, ach={:.2}, serotonin={:.2}",
+        focused.dopamine, focused.norepinephrine, focused.acetylcholine, focused.serotonin
     );
     println!("  Neurons spiked: {}", spikes.len());
-    println!("  STDP learning: ENABLED");
     println!(
-        "  Decay rate adjustment: {:.3} (reduced for better memory)",
-        0.15 - 0.05 * modulators.acetylcholine
+        "  Membrane decay rate: {:.3} (reduced for better memory)",
+        network.neurons[0].decay_rate
     );
-    println!();
+    println!(
+        "  Firing threshold:    {:.3}\n",
+        network.neurons[0].threshold
+    );
+
+    println!("--- Scenario 5: Slower Traces via `RmStdpConfig` ---");
+    network.set_rm_stdp_config(RmStdpConfig {
+        tau_eligibility: 200.0,
+        reward_lr: 0.02,
+        ..RmStdpConfig::default()
+    });
+    println!(
+        "  tau_eligibility -> {:.1}, reward_lr -> {:.3}",
+        network.stdp_config.tau_eligibility, network.stdp_config.reward_lr
+    );
+    println!(
+        "  Traces now hold credit ~4x longer and pay out more slowly; existing\n  \
+         traces keep their accumulated value and adopt the new tau: {:.1}\n",
+        network.neurons[0].eligibility[0].tau
+    );
 
     println!("=== Modulator Operations Demo ===\n");
 
@@ -142,7 +191,7 @@ fn main() {
     println!("  Serotonin: {:.2}", mods.serotonin);
 
     let reward = UnitReward;
-    let observation = Observation::from_slice(&stimuli);
+    let observation = Observation::from_slice(&STIMULI);
     mods.apply_reward(&reward, &observation);
     println!(
         "\nApplied GenericReward (UnitReward): dopamine={:.2}",
@@ -158,10 +207,13 @@ fn main() {
 
     println!("\n=== Demo Complete ===");
     println!("Key takeaways:");
-    println!("  • Dopamine enables STDP learning (credit assignment)");
+    println!("  • Eligibility traces accumulate every step, dopamine or not");
+    println!("  • Dopamine gates only the trace -> weight conversion (credit assignment)");
+    println!("  • Reward can therefore arrive after the coincidence it pays for");
     println!("  • Norepinephrine reduces network sensitivity (stress response)");
     println!("  • Acetylcholine adjusts decay rates (focus/memory)");
     println!("  • Serotonin stabilizes firing thresholds");
+    println!("  • `RmStdpConfig` tunes trace decay, reward rate, and weight bounds");
     println!("  • GenericReward allows domain-specific reward shaping upstream");
     println!("  • Decay provides homeostasis (modulators return to baseline)");
 }

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -28,19 +28,28 @@ fn report(network: &SpikingNetwork, label: &str) {
     println!();
 }
 
-fn main() {
-    println!("=== Reward-Modulated STDP Demo ===\n");
+/// The reward state Scenarios 2 and 5 both drive with.
+fn rewarded_state() -> NeuroModulators {
+    NeuroModulators {
+        dopamine: 0.9,
+        norepinephrine: 0.1,
+        acetylcholine: 0.7,
+        ..Default::default()
+    }
+}
 
+/// Four LIF neurons over four channels, every synapse seeded at an equal share
+/// of the engine's L1 weight budget so the renormalization pass starts neutral
+/// and any drift below is learning.
+fn build_network(seed: f32) -> SpikingNetwork {
     let mut network = SpikingNetwork::with_dimensions(4, 2, STIMULI.len());
-
-    // Seed every synapse at an equal share of the engine's L1 weight budget, so
-    // the renormalization pass starts neutral and any drift below is learning.
-    let seed = 2.0 / STIMULI.len() as f32;
     for neuron in &mut network.neurons {
         neuron.weights = vec![seed; STIMULI.len()];
     }
+    network
+}
 
-    let config = RmStdpConfig::default();
+fn print_setup(network: &SpikingNetwork, config: &RmStdpConfig, seed: f32) {
     println!("Network initialized:");
     println!("  LIF neurons:        {}", network.neurons.len());
     println!("  Izhikevich neurons: {}", network.iz_neurons.len());
@@ -54,33 +63,32 @@ fn main() {
         config.w_min, config.w_max
     );
     println!("\nStimuli: {STIMULI:?}  (channels 0-1 driven, 2-3 silent)\n");
+}
 
-    println!("=== Simulation Scenarios ===\n");
-
+/// Dopamine off: the driven synapses bank credit they are not paid for.
+fn scenario_no_reward(network: &mut SpikingNetwork, config: &RmStdpConfig, seed: f32) {
     println!("--- Scenario 1: No Reward — credit is earned, not yet paid ---");
     let no_reward = NeuroModulators::default();
     println!("  dopamine={:.2}\n", no_reward.dopamine);
-    report(&network, "before");
+    report(network, "before");
     for _ in 0..10 {
         network
             .step(&STIMULI, &no_reward)
             .expect("stimuli length must match network channels");
     }
-    report(&network, "after 10 steps");
+    report(network, "after 10 steps");
     println!(
         "  Weights held at {seed:.4}: the dopamine gate is shut. The driven\n  \
          synapses still banked eligibility (e > 0) — that credit stays claimable\n  \
          for roughly {:.0} steps.\n",
         config.tau_eligibility
     );
+}
 
+/// Dopamine on: the banked traces convert into weight changes.
+fn scenario_reward(network: &mut SpikingNetwork, config: &RmStdpConfig) {
     println!("--- Scenario 2: Reward State (High Dopamine) — the trace is cashed in ---");
-    let rewarded = NeuroModulators {
-        dopamine: 0.9,
-        norepinephrine: 0.1,
-        acetylcholine: 0.7,
-        ..Default::default()
-    };
+    let rewarded = rewarded_state();
     println!(
         "  dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
         rewarded.dopamine, rewarded.norepinephrine, rewarded.acetylcholine
@@ -97,7 +105,7 @@ fn main() {
             .step(&STIMULI, &rewarded)
             .expect("stimuli length must match network channels");
     }
-    report(&network, "after 10 steps");
+    report(network, "after 10 steps");
     print!("  Weight deltas:        ");
     for (ch, (&now, &then)) in network.neurons[0]
         .weights
@@ -114,7 +122,9 @@ fn main() {
          renormalization pass — which is why channels 2 and 3 moved at all despite\n  \
          holding no trace: the driven synapses took share of a fixed budget.\n"
     );
+}
 
+fn scenario_stress(network: &mut SpikingNetwork) {
     println!("--- Scenario 3: Stress State (High Norepinephrine) ---");
     let stressed = NeuroModulators {
         dopamine: 0.2,
@@ -136,7 +146,9 @@ fn main() {
          accumulation.\n",
         (1.0 - stressed.norepinephrine).max(0.1)
     );
+}
 
+fn scenario_focus(network: &mut SpikingNetwork) {
     println!("--- Scenario 4: Focus State (High Acetylcholine) ---");
     let focused = NeuroModulators {
         dopamine: 0.6,
@@ -160,7 +172,11 @@ fn main() {
         "  Firing threshold:    {:.3}\n",
         network.neurons[0].threshold
     );
+}
 
+/// A/B the reconfigured network against an otherwise identical twin left on the
+/// defaults, so the effect of `RmStdpConfig` is measured rather than asserted.
+fn scenario_slow_traces(network: &mut SpikingNetwork) {
     println!("--- Scenario 5: Slower Traces via `RmStdpConfig` ---");
     // Snapshot the network before touching its config. The twin inherits this
     // exact state and keeps the defaults, then sees the identical stimuli and
@@ -193,6 +209,7 @@ fn main() {
     );
 
     // Same 10 rewarded steps Scenario 2 used, run on both networks.
+    let rewarded = rewarded_state();
     for _ in 0..10 {
         network
             .step(&STIMULI, &rewarded)
@@ -201,7 +218,7 @@ fn main() {
             .step(&STIMULI, &rewarded)
             .expect("stimuli length must match network channels");
     }
-    report(&network, "slow config");
+    report(network, "slow config");
     report(&default_twin, "default config");
 
     let slow_gain = network.neurons[0].weights[0] - entry_weight;
@@ -223,7 +240,10 @@ fn main() {
         per_step_loss(network.stdp_config.tau_eligibility),
         per_step_loss(default_twin.stdp_config.tau_eligibility),
     );
+}
 
+/// The modulator helpers, independent of the engine.
+fn modulator_operations() {
     println!("=== Modulator Operations Demo ===\n");
 
     let mut mods = NeuroModulators::default();
@@ -258,7 +278,9 @@ fn main() {
         "  After decay - Dopamine: {:.2}, Norepinephrine: {:.2}, Ach: {:.2}, Serotonin: {:.2}",
         mods.dopamine, mods.norepinephrine, mods.acetylcholine, mods.serotonin
     );
+}
 
+fn print_takeaways() {
     println!("\n=== Demo Complete ===");
     println!("Key takeaways:");
     println!("  • Eligibility traces accumulate every step, dopamine or not");
@@ -270,4 +292,23 @@ fn main() {
     println!("  • `RmStdpConfig` tunes trace decay, reward rate, and weight bounds");
     println!("  • GenericReward allows domain-specific reward shaping upstream");
     println!("  • Decay provides homeostasis (modulators return to baseline)");
+}
+
+fn main() {
+    println!("=== Reward-Modulated STDP Demo ===\n");
+
+    let seed = 2.0 / STIMULI.len() as f32;
+    let mut network = build_network(seed);
+    let config = RmStdpConfig::default();
+    print_setup(&network, &config, seed);
+
+    println!("=== Simulation Scenarios ===\n");
+    scenario_no_reward(&mut network, &config, seed);
+    scenario_reward(&mut network, &config);
+    scenario_stress(&mut network);
+    scenario_focus(&mut network);
+    scenario_slow_traces(&mut network);
+
+    modulator_operations();
+    print_takeaways();
 }

--- a/examples/rstdp_demo.rs
+++ b/examples/rstdp_demo.rs
@@ -4,8 +4,9 @@
 //! per-synapse eligibility traces accumulate spike-timing coincidences on
 //! every step, and dopamine converts those traces into weight changes.
 //!
-//! Every number below is read back out of the network after `step` — nothing
-//! here is narrated from a constant.
+//! The weight and eligibility reports are read back out of the network after
+//! `step`, not narrated from constants. Setup lines, stimuli, and modulator
+//! levels print the inputs used to drive it.
 //!
 //! Run with: cargo run --example rstdp_demo
 
@@ -84,7 +85,12 @@ fn main() {
         "  dopamine={:.2}, norepinephrine={:.2}, ach={:.2}",
         rewarded.dopamine, rewarded.norepinephrine, rewarded.acetylcholine
     );
-    println!("  learning rate: {:.3}\n", 0.5 * rewarded.dopamine);
+    let dopamine_lr = 0.5 * rewarded.dopamine;
+    println!(
+        "  dopamine_lr: {dopamine_lr:.3}  (trace payout factor \
+         reward_lr x dopamine_lr = {:.4})\n",
+        config.reward_lr * dopamine_lr
+    );
     let before = network.neurons[0].weights.clone();
     for _ in 0..10 {
         network
@@ -103,9 +109,10 @@ fn main() {
     }
     println!();
     println!(
-        "  Driven synapses potentiated; silent ones lost share of the fixed L1\n  \
-         budget. No hand-written rule ran here — the deltas are\n  \
-         reward_lr x dopamine_lr x eligibility.\n"
+        "  The trace payout itself is reward_lr x dopamine_lr x eligibility, applied\n  \
+         per synapse. These printed deltas are that payout *after* the L1\n  \
+         renormalization pass — which is why channels 2 and 3 moved at all despite\n  \
+         holding no trace: the driven synapses took share of a fixed budget.\n"
     );
 
     println!("--- Scenario 3: Stress State (High Norepinephrine) ---");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -956,6 +956,38 @@ mod tests {
     }
 
     #[test]
+    fn test_negative_w_min_cannot_make_weights_inhibitory() {
+        // Ordered and finite, but inhibitory — unsupported by this crate. Left
+        // unguarded, a rewarded depression drives weights negative and the L1
+        // pass then skips the neuron forever, since a negative total never
+        // satisfies its `> 1e-6` guard.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![0.5, 0.5];
+        network.set_rm_stdp_config(RmStdpConfig {
+            w_min: -2.0,
+            w_max: -1.0,
+            ..RmStdpConfig::default()
+        });
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        for _ in 0..5 {
+            network.step(&[1.0, 1.0], &reward).expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            assert!(
+                neuron.weights.iter().all(|&w| w >= 0.0),
+                "weights must stay excitatory: {:?}",
+                neuron.weights
+            );
+        }
+        assert_eq!(network.stdp_config.weight_bounds(), (0.0, 2.0));
+    }
+
+    #[test]
     fn test_pre_0_6_state_without_new_fields_loads_and_steps() {
         let mut network = SpikingNetwork::with_dimensions(2, 1, 3);
         for neuron in &mut network.neurons {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -80,8 +80,10 @@ impl SpikingNetwork {
             .map(|_| {
                 let mut n = LifNeuron::new();
                 n.weights = vec![0.0; num_channels];
-                n.eligibility =
-                    vec![EligibilityTrace::new(stdp_config.tau_eligibility); num_channels];
+                n.eligibility = vec![
+                    EligibilityTrace::new(stdp_config.effective_tau_eligibility());
+                    num_channels
+                ];
                 n.last_spike_time = -1;
                 n
             })
@@ -121,9 +123,10 @@ impl SpikingNetwork {
     /// ```
     pub fn set_rm_stdp_config(&mut self, config: RmStdpConfig) {
         self.stdp_config = config;
+        let tau = config.effective_tau_eligibility();
         for neuron in &mut self.neurons {
             for trace in &mut neuron.eligibility {
-                trace.tau = config.tau_eligibility;
+                trace.tau = tau;
             }
         }
     }
@@ -274,6 +277,15 @@ impl SpikingNetwork {
             if total > 1e-6 {
                 let scale = WEIGHT_BUDGET / total;
                 for w in &mut neuron.weights {
+                    // A synapse at exactly zero is unconnected. Rescaling and
+                    // capping the connected ones is this pass's job, but a
+                    // positive `w_min` must not conjure a connection here: this
+                    // loop runs every step, dopamine or not, and an unrewarded
+                    // step must leave weights alone. Learning raises a synapse
+                    // to the floor in `apply_stdp`, which is reward-gated.
+                    if *w == 0.0 {
+                        continue;
+                    }
                     *w *= scale;
                     *w = w.clamp(w_min, w_max);
                 }
@@ -320,7 +332,7 @@ impl SpikingNetwork {
             if neuron.eligibility.len() != neuron.weights.len() {
                 neuron.eligibility.resize(
                     neuron.weights.len(),
-                    EligibilityTrace::new(config.tau_eligibility),
+                    EligibilityTrace::new(config.effective_tau_eligibility()),
                 );
             }
 
@@ -842,6 +854,60 @@ mod tests {
                 neuron.weights.iter().all(|&w| w == 0.0),
                 "a positive w_min must not seed blank weights: {:?}",
                 neuron.weights
+            );
+        }
+    }
+
+    #[test]
+    fn test_positive_w_min_does_not_seed_untouched_zero_weights() {
+        // A partially connected neuron: channel 0 carries the whole budget,
+        // channel 1 is unconnected. The nonzero total clears the `> 1e-6` guard,
+        // so this reaches the clamp that a fully blank network never does.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![WEIGHT_BUDGET, 0.0];
+        network.set_rm_stdp_config(RmStdpConfig {
+            w_min: 0.1,
+            ..RmStdpConfig::default()
+        });
+        let no_reward = NeuroModulators::default();
+
+        network
+            .step(&[0.0, 0.0], &no_reward)
+            .expect("length matches");
+
+        assert_eq!(
+            network.neurons[0].weights[1], 0.0,
+            "an unrewarded step must not conjure a connection out of w_min"
+        );
+        assert_eq!(network.neurons[0].weights[0], WEIGHT_BUDGET);
+    }
+
+    #[test]
+    fn test_non_finite_tau_eligibility_neither_erases_nor_freezes_traces() {
+        for bad_tau in [f32::NAN, f32::INFINITY, 0.0, -5.0] {
+            let mut network = rstdp_test_network();
+            network.set_rm_stdp_config(RmStdpConfig {
+                tau_eligibility: bad_tau,
+                ..RmStdpConfig::default()
+            });
+            let no_reward = NeuroModulators::default();
+
+            for _ in 0..10 {
+                network
+                    .step(&DRIVEN_AND_SILENT, &no_reward)
+                    .expect("length matches");
+            }
+
+            // The default tau is installed instead, so credit is neither wiped
+            // (NaN) nor held forever (+inf): it banks like any other run.
+            let trace = network.neurons[0].eligibility[0].value;
+            assert!(
+                trace > 0.0 && trace.is_finite(),
+                "tau {bad_tau} should fall back to the default, got trace {trace}"
+            );
+            assert_eq!(
+                network.neurons[0].eligibility[0].tau,
+                RmStdpConfig::default().tau_eligibility
             );
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -310,6 +310,7 @@ impl SpikingNetwork {
         let now = self.global_step;
         let config = self.stdp_config;
         let (w_min, w_max) = config.weight_bounds();
+        let reward_lr = config.effective_reward_lr();
         let rewarding = dopamine_lr >= 1e-6;
         let input_times = &self.input_spike_times;
 
@@ -342,7 +343,7 @@ impl SpikingNetwork {
                 }
 
                 if rewarding && trace.value != 0.0 {
-                    let dw = config.reward_lr * dopamine_lr * trace.value;
+                    let dw = reward_lr * dopamine_lr * trace.value;
                     neuron.weights[ch] = (neuron.weights[ch] + dw).clamp(w_min, w_max);
                 }
             }
@@ -787,6 +788,60 @@ mod tests {
             assert!(
                 total < WEIGHT_BUDGET,
                 "a binding w_max holds the L1 sum under budget: got {total}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_non_finite_reward_lr_cannot_poison_weights() {
+        // A NaN weight would survive forever: renormalization skips a neuron
+        // whose total is not `> 1e-6`, and `NaN > 1e-6` is false.
+        let mut network = rstdp_test_network();
+        network.stdp_config.reward_lr = f32::NAN;
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        for _ in 0..10 {
+            network
+                .step(&DRIVEN_AND_SILENT, &reward)
+                .expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            assert!(
+                neuron.weights.iter().all(|w| w.is_finite()),
+                "a non-finite reward_lr must not poison weights: {:?}",
+                neuron.weights
+            );
+        }
+    }
+
+    #[test]
+    fn test_positive_w_min_does_not_seed_a_blank_network() {
+        // Blank weights are the documented neutral initialization. Bounds gate
+        // weight *updates*; they do not fabricate synaptic weight where the
+        // network deliberately has none.
+        let mut network = SpikingNetwork::with_dimensions(2, 1, 4);
+        network.set_rm_stdp_config(RmStdpConfig {
+            w_min: 0.1,
+            ..RmStdpConfig::default()
+        });
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        for _ in 0..5 {
+            network.step(&[1.0; 4], &reward).expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            assert!(
+                neuron.weights.iter().all(|&w| w == 0.0),
+                "a positive w_min must not seed blank weights: {:?}",
+                neuron.weights
             );
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -301,7 +301,8 @@ impl SpikingNetwork {
                     // positive `w_min` must not conjure a connection here: this
                     // loop runs every step, dopamine or not, and an unrewarded
                     // step must leave weights alone. Learning raises a synapse
-                    // to the floor in `apply_stdp`, which is reward-gated.
+                    // to the floor in `apply_stdp`, and only on a step where it
+                    // actually applies an update.
                     if *w == 0.0 {
                         continue;
                     }
@@ -384,7 +385,15 @@ impl SpikingNetwork {
 
                 if rewarding && trace.value != 0.0 {
                     let dw = reward_lr * dopamine_lr * trace.value;
-                    neuron.weights[ch] = (neuron.weights[ch] + dw).clamp(w_min, w_max);
+                    // No update, nothing to clamp. Writing anyway would let the
+                    // bounds move a weight on their own: `reward_lr = 0.0`
+                    // disables conversion, yet a positive `w_min` would still
+                    // lift an unconnected synapse to the floor, and the L1 pass
+                    // then scales that fabricated weight toward the budget.
+                    // Bounds are enforced where a weight actually changes.
+                    if dw != 0.0 {
+                        neuron.weights[ch] = (neuron.weights[ch] + dw).clamp(w_min, w_max);
+                    }
                 }
             }
         }
@@ -676,6 +685,40 @@ mod tests {
             "deferred credit: reward converts the banked trace with no new spikes"
         );
         assert!(network.neurons[0].weights[0] > network.neurons[0].weights[1]);
+    }
+    #[test]
+    fn test_zero_reward_rate_leaves_an_unconnected_synapse_at_zero() {
+        // `reward_lr = 0.0` turns trace conversion off. A positive `w_min` must
+        // not then stand in for it: with no update applied there is nothing to
+        // clamp, and raising an unconnected synapse to the floor would let a
+        // disabled learning rate change connectivity. The renormalization pass
+        // would then scale that fabricated weight toward the budget.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![0.0, WEIGHT_BUDGET];
+        network.set_rm_stdp_config(RmStdpConfig {
+            reward_lr: 0.0,
+            w_min: 0.1,
+            ..RmStdpConfig::default()
+        });
+        // Credit is banked, so the conversion branch is entered every step.
+        network.neurons[0].eligibility[0].value = 0.5;
+
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+        for _ in 0..5 {
+            network.step(&[0.0, 0.0], &reward).expect("length matches");
+        }
+
+        assert!(
+            network.neurons[0].eligibility[0].value > 0.0,
+            "the trace should still be banked, so the branch really ran"
+        );
+        assert_eq!(
+            network.neurons[0].weights[0], 0.0,
+            "a zero learning rate applied no update, so the floor must not connect this synapse"
+        );
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -104,6 +104,14 @@ impl SpikingNetwork {
     /// Replace the R-STDP hyperparameters, re-`tau`-ing every existing
     /// eligibility trace so traces and config stay consistent.
     ///
+    /// The config is **normalized on the way in**: each field passes through its
+    /// guard ([`RmStdpConfig::weight_bounds`],
+    /// [`RmStdpConfig::effective_reward_lr`],
+    /// [`RmStdpConfig::effective_tau_eligibility`]), so a reversed or non-finite
+    /// value is replaced by the published default rather than stored and worked
+    /// around later. Assigning [`Self::stdp_config`] directly bypasses this; the
+    /// engine still reads through the same guards, so it stays safe either way.
+    ///
     /// Accumulated trace *values* are preserved — only the decay time constant
     /// changes. Use [`Self::reset`] to clear them.
     ///
@@ -122,8 +130,15 @@ impl SpikingNetwork {
     /// assert_eq!(net.neurons[0].eligibility[0].tau, 100.0);
     /// ```
     pub fn set_rm_stdp_config(&mut self, config: RmStdpConfig) {
-        self.stdp_config = config;
+        let (w_min, w_max) = config.weight_bounds();
         let tau = config.effective_tau_eligibility();
+        self.stdp_config = RmStdpConfig {
+            tau_eligibility: tau,
+            reward_lr: config.effective_reward_lr(),
+            w_min,
+            w_max,
+        };
+
         for neuron in &mut self.neurons {
             for trace in &mut neuron.eligibility {
                 trace.tau = tau;
@@ -156,11 +171,15 @@ impl SpikingNetwork {
     ///    into weight changes only when the dopamine-derived learning rate is
     ///    above ≈ 0.
     /// 8. Renormalize LIF weights toward an L1 budget, then clamp to the
-    ///    [`RmStdpConfig`] bounds. **Bounds take precedence over the budget.**
-    ///    Under the default bounds the clamp provably cannot bind — weights are
-    ///    non-negative and `w_max` equals the budget — so the L1 sum lands on
-    ///    budget exactly. Narrowed bounds are still enforced, and the sum then
-    ///    settles off budget by however much they bind.
+    ///    [`RmStdpConfig`] bounds. Applies only to a neuron whose weights already
+    ///    sum above `1e-6`; a blank neuron stays blank rather than being scaled
+    ///    up to the budget, and a synapse at exactly zero is left alone so a
+    ///    positive `w_min` cannot conjure a connection on an unrewarded step.
+    ///    **Bounds take precedence over the budget.** Under the default bounds
+    ///    the clamp provably cannot bind — weights are non-negative and `w_max`
+    ///    equals the budget — so the L1 sum lands on budget exactly. A binding
+    ///    bound is still enforced, leaving the sum off budget in whichever
+    ///    direction it binds.
     /// 9. Drive each Izhikevich neuron from mean LIF membrane potential + dopamine.
     ///
     /// # Examples
@@ -725,6 +744,30 @@ mod tests {
                     .eligibility
                     .iter()
                     .all(|t| t.tau == network.stdp_config.tau_eligibility)
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_rm_stdp_config_normalizes_what_it_stores() {
+        let mut network = rstdp_test_network();
+
+        network.set_rm_stdp_config(RmStdpConfig {
+            tau_eligibility: f32::NAN,
+            reward_lr: f32::INFINITY,
+            w_min: 1.5,
+            w_max: 0.2, // reversed
+        });
+
+        // The setter installs guarded values rather than storing nonsense and
+        // working around it at every read.
+        assert_eq!(network.stdp_config, RmStdpConfig::default());
+        for neuron in &network.neurons {
+            assert!(
+                neuron
+                    .eligibility
+                    .iter()
+                    .all(|t| t.tau == RmStdpConfig::default().tau_eligibility)
             );
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -405,6 +405,19 @@ impl SpikingNetwork {
                     }
                 }
             }
+
+            // A caller can hand a neuron more weights than the network has
+            // channels. Those synapses have no input that could spike, so they
+            // only ever decay — but the loop above stops at the last channel,
+            // which would leave a planted or deserialized trace frozen there
+            // forever. Empty in the usual case, where the two lengths agree.
+            for trace in neuron.eligibility.iter_mut().skip(input_times.len()) {
+                if !trace.value.is_finite() {
+                    trace.reset();
+                } else if trace.value != 0.0 {
+                    trace.decay();
+                }
+            }
         }
     }
 
@@ -814,6 +827,30 @@ mod tests {
             network.neurons[0].weights[0],
             network.stdp_config.weight_bounds().0,
             "depression must clamp at w_min, not go negative"
+        );
+    }
+    #[test]
+    fn test_traces_past_the_last_channel_still_decay() {
+        // Two channels, but a caller widened this neuron to four synapses. The
+        // extra two have no input that could ever spike, so decay is all they
+        // can do — and the per-channel loop stops before reaching them, which
+        // left a planted trace frozen there across every step.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![WEIGHT_BUDGET / 4.0; 4];
+        network.neurons[0].eligibility = vec![EligibilityTrace::new(50.0); 4];
+        network.neurons[0].eligibility[3].value = 0.5;
+
+        let no_reward = NeuroModulators::default();
+        for _ in 0..5 {
+            network
+                .step(&[0.0, 0.0], &no_reward)
+                .expect("length matches");
+        }
+
+        let orphan = network.neurons[0].eligibility[3].value;
+        assert!(
+            orphan > 0.0 && orphan < 0.5,
+            "a trace past the last channel should decay toward zero, got {orphan}"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -385,14 +385,23 @@ impl SpikingNetwork {
 
                 if rewarding && trace.value != 0.0 {
                     let dw = reward_lr * dopamine_lr * trace.value;
-                    // No update, nothing to clamp. Writing anyway would let the
-                    // bounds move a weight on their own: `reward_lr = 0.0`
-                    // disables conversion, yet a positive `w_min` would still
-                    // lift an unconnected synapse to the floor, and the L1 pass
-                    // then scales that fabricated weight toward the budget.
-                    // Bounds are enforced where a weight actually changes.
-                    if dw != 0.0 {
-                        neuron.weights[ch] = (neuron.weights[ch] + dw).clamp(w_min, w_max);
+                    let w = neuron.weights[ch];
+                    // The bounds must never move a weight on their own. Writing
+                    // unconditionally lets them do exactly that on a synapse
+                    // left at exactly zero -- unconnected, the state the L1 pass
+                    // below is careful to preserve -- in two ways:
+                    //
+                    // - `reward_lr = 0.0` disables conversion, yet a `dw` of
+                    //   zero still clamps the synapse up to a positive `w_min`.
+                    // - Depression (`dw < 0`) has nothing to take away, and its
+                    //   negative result clamps up to `w_min` too, connecting a
+                    //   synapse by weakening it.
+                    //
+                    // Potentiation is the one update that may bring a synapse
+                    // online, and it still lands on the floor where `w_min`
+                    // binds. Everywhere else the L1 pass re-clamps each step.
+                    if dw > 0.0 || (dw < 0.0 && w != 0.0) {
+                        neuron.weights[ch] = (w + dw).clamp(w_min, w_max);
                     }
                 }
             }
@@ -742,6 +751,65 @@ mod tests {
             "post-before-pre is depression, got {}",
             network.neurons[0].eligibility[0].value
         );
+        assert_eq!(
+            network.neurons[0].weights[0],
+            network.stdp_config.weight_bounds().0,
+            "depression must clamp at w_min, not go negative"
+        );
+    }
+    #[test]
+    fn test_rewarded_depression_does_not_connect_a_zero_weight_synapse() {
+        // Depression on an unconnected synapse: `(0.0 + dw).clamp(w_min, w_max)`
+        // with a negative `dw` and a positive floor returns `w_min`, so paying
+        // out a negative trace would *create* the connection depression is
+        // supposed to weaken. Skipping a zero update is not enough here -- `dw`
+        // is genuinely non-zero, it just points the wrong way.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![0.0, WEIGHT_BUDGET];
+        network.set_rm_stdp_config(RmStdpConfig {
+            w_min: 0.1,
+            ..RmStdpConfig::default()
+        });
+        // Zero weight on channel 0 means no drive from it, so the neuron cannot
+        // fire and keeps the post spike planted here -- strictly before the pre
+        // spike channel 0 emits on the step below.
+        network.neurons[0].last_spike_time = 0;
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        network.step(&[1.0, 0.0], &reward).expect("length matches");
+
+        assert_eq!(network.neurons[0].last_spike_time, 0, "must not have fired");
+        assert!(
+            network.neurons[0].eligibility[0].value < 0.0,
+            "expected a depressing trace, got {}",
+            network.neurons[0].eligibility[0].value
+        );
+        assert_eq!(
+            network.neurons[0].weights[0], 0.0,
+            "depression must not lift an unconnected synapse to the floor"
+        );
+    }
+    #[test]
+    fn test_depression_clamps_a_connected_synapse_at_w_min() {
+        // The floor still binds wherever an update actually applies: a
+        // *connected* synapse depressed past `w_min` stops there instead of
+        // going negative. This is the other half of the test above, which
+        // covers the synapse that must not be connected in the first place.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![0.001, WEIGHT_BUDGET];
+        network.neurons[0].eligibility[0].value = -0.5;
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        // Zero stimuli: nothing spikes, so the banked trace is the only input
+        // to the update and its sign is not in doubt.
+        network.step(&[0.0, 0.0], &reward).expect("length matches");
+
         assert_eq!(
             network.neurons[0].weights[0],
             network.stdp_config.weight_bounds().0,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -152,8 +152,12 @@ impl SpikingNetwork {
     ///    [`crate::EligibilityTrace`] regardless of dopamine, then convert traces
     ///    into weight changes only when the dopamine-derived learning rate is
     ///    above ≈ 0.
-    /// 8. Renormalize LIF weights to an L1 budget and clamp to the
-    ///    [`RmStdpConfig`] bounds.
+    /// 8. Renormalize LIF weights toward an L1 budget, then clamp to the
+    ///    [`RmStdpConfig`] bounds. **Bounds take precedence over the budget.**
+    ///    Under the default bounds the clamp provably cannot bind — weights are
+    ///    non-negative and `w_max` equals the budget — so the L1 sum lands on
+    ///    budget exactly. Narrowed bounds are still enforced, and the sum then
+    ///    settles off budget by however much they bind.
     /// 9. Drive each Izhikevich neuron from mean LIF membrane potential + dopamine.
     ///
     /// # Examples
@@ -260,6 +264,10 @@ impl SpikingNetwork {
 
         self.apply_stdp(learning_rate);
 
+        // Scale toward the L1 budget, then enforce the configured bounds. The
+        // bounds win where the two disagree: under the defaults they cannot
+        // bind here, so the budget holds exactly; a narrowed range is honored
+        // and leaves the sum off budget. See the `step` contract, item 8.
         let (w_min, w_max) = self.stdp_config.weight_bounds();
         for neuron in &mut self.neurons {
             let total: f32 = neuron.weights.iter().sum();
@@ -727,10 +735,35 @@ mod tests {
     }
 
     #[test]
-    fn test_config_weight_bounds_are_enforced_by_step() {
+    fn test_default_bounds_keep_the_l1_sum_on_budget() {
+        let mut network = rstdp_test_network();
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        for _ in 0..40 {
+            network
+                .step(&DRIVEN_AND_SILENT, &reward)
+                .expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            let total: f32 = neuron.weights.iter().sum();
+            assert!(
+                (total - WEIGHT_BUDGET).abs() < 1e-4,
+                "the default clamp cannot bind, so the budget holds: got {total}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_configured_bounds_take_precedence_over_the_l1_budget() {
+        // Four channels capped at 0.4 cannot reach the budget of 2.0 — the
+        // documented precedence is that the bound wins and the sum sits under.
         let mut network = rstdp_test_network();
         network.set_rm_stdp_config(RmStdpConfig {
-            w_max: 0.55,
+            w_max: 0.4,
             ..RmStdpConfig::default()
         });
         let reward = NeuroModulators {
@@ -738,7 +771,7 @@ mod tests {
             ..Default::default()
         };
 
-        for _ in 0..60 {
+        for _ in 0..40 {
             network
                 .step(&DRIVEN_AND_SILENT, &reward)
                 .expect("length matches");
@@ -746,9 +779,14 @@ mod tests {
 
         for neuron in &network.neurons {
             assert!(
-                neuron.weights.iter().all(|&w| w <= 0.55 + 1e-6),
+                neuron.weights.iter().all(|&w| w <= 0.4 + 1e-6),
                 "weights must respect the configured w_max: {:?}",
                 neuron.weights
+            );
+            let total: f32 = neuron.weights.iter().sum();
+            assert!(
+                total < WEIGHT_BUDGET,
+                "a binding w_max holds the L1 sum under budget: got {total}"
             );
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -13,9 +13,11 @@
 //! For classical Hebbian STDP on a small Izhikevich network, see
 //! [`crate::hebbian`] — that path is separate from this engine.
 //!
-//! Plasticity honesty: live reward-modulated updates run inside `step` via
-//! `apply_stdp` (dopamine-gated). [`crate::EligibilityTrace`] is a building
-//! block and is **not** consumed by the engine yet (see [`crate::rm_stdp`]).
+//! Plasticity: live reward-modulated updates run inside `step` via `apply_stdp`.
+//! Every step decays and accumulates one [`crate::EligibilityTrace`] per synapse;
+//! dopamine gates only the trace → weight conversion, so a coincidence recorded
+//! while reward was absent can still be paid out later (see [`crate::rm_stdp`]
+//! and [`RmStdpConfig`]).
 
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
@@ -55,6 +57,14 @@ pub struct SpikingNetwork {
     pub input_spike_times: Vec<i64>,
     /// Per-channel exponential moving average of input stimuli.
     pub predictive_state: Vec<f32>,
+    /// R-STDP hyperparameters: eligibility-trace decay, the reward learning
+    /// rate used to convert traces into weight changes, and the weight bounds
+    /// enforced by `apply_stdp` and the L1 renormalization pass.
+    ///
+    /// Assigning this field directly leaves existing traces on their previous
+    /// `tau`; use [`SpikingNetwork::set_rm_stdp_config`] to update both.
+    #[serde(default)]
+    pub stdp_config: RmStdpConfig,
 }
 
 impl SpikingNetwork {
@@ -65,10 +75,13 @@ impl SpikingNetwork {
 
     /// Create a dynamically sized network.
     pub fn with_dimensions(num_lif: usize, num_izh: usize, num_channels: usize) -> Self {
+        let stdp_config = RmStdpConfig::default();
         let neurons: Vec<LifNeuron> = (0..num_lif)
             .map(|_| {
                 let mut n = LifNeuron::new();
                 n.weights = vec![0.0; num_channels];
+                n.eligibility =
+                    vec![EligibilityTrace::new(stdp_config.tau_eligibility); num_channels];
                 n.last_spike_time = -1;
                 n
             })
@@ -82,6 +95,36 @@ impl SpikingNetwork {
             num_channels,
             input_spike_times: vec![-1; num_channels],
             predictive_state: vec![0.0; num_channels],
+            stdp_config,
+        }
+    }
+
+    /// Replace the R-STDP hyperparameters, re-`tau`-ing every existing
+    /// eligibility trace so traces and config stay consistent.
+    ///
+    /// Accumulated trace *values* are preserved — only the decay time constant
+    /// changes. Use [`Self::reset`] to clear them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neuromod::{RmStdpConfig, SpikingNetwork};
+    ///
+    /// let mut net = SpikingNetwork::with_dimensions(4, 1, 4);
+    /// net.set_rm_stdp_config(RmStdpConfig {
+    ///     tau_eligibility: 100.0,
+    ///     reward_lr: 0.02,
+    ///     ..RmStdpConfig::default()
+    /// });
+    ///
+    /// assert_eq!(net.neurons[0].eligibility[0].tau, 100.0);
+    /// ```
+    pub fn set_rm_stdp_config(&mut self, config: RmStdpConfig) {
+        self.stdp_config = config;
+        for neuron in &mut self.neurons {
+            for trace in &mut neuron.eligibility {
+                trace.tau = config.tau_eligibility;
+            }
         }
     }
 
@@ -105,9 +148,12 @@ impl SpikingNetwork {
     ///    `input_spike_times` on success.
     /// 5. Integrate each LIF neuron (weighted stimuli + surprise), then `check_fire`.
     /// 6. Lateral inhibition on non-firing LIF cells if anyone spiked.
-    /// 7. Dopamine-gated STDP on LIF weights (`apply_stdp`); skipped if learning
-    ///    rate ≈ 0. Weights are **not** updated via [`crate::EligibilityTrace`].
-    /// 8. Renormalize LIF weights to an L1 budget and clamp to R-STDP bounds.
+    /// 7. R-STDP on LIF weights (`apply_stdp`): decay and accumulate every
+    ///    [`crate::EligibilityTrace`] regardless of dopamine, then convert traces
+    ///    into weight changes only when the dopamine-derived learning rate is
+    ///    above ≈ 0.
+    /// 8. Renormalize LIF weights to an L1 budget and clamp to the
+    ///    [`RmStdpConfig`] bounds.
     /// 9. Drive each Izhikevich neuron from mean LIF membrane potential + dopamine.
     ///
     /// # Examples
@@ -214,13 +260,14 @@ impl SpikingNetwork {
 
         self.apply_stdp(learning_rate);
 
+        let (w_min, w_max) = self.stdp_config.weight_bounds();
         for neuron in &mut self.neurons {
             let total: f32 = neuron.weights.iter().sum();
             if total > 1e-6 {
                 let scale = WEIGHT_BUDGET / total;
                 for w in &mut neuron.weights {
                     *w *= scale;
-                    *w = w.clamp(RM_STDP_W_MIN, RM_STDP_W_MAX);
+                    *w = w.clamp(w_min, w_max);
                 }
             }
         }
@@ -240,37 +287,56 @@ impl SpikingNetwork {
         Ok(spike_ids)
     }
 
+    /// Reward-modulated STDP over the per-synapse eligibility traces.
+    ///
+    /// Runs on every step. Traces decay and accumulate independently of
+    /// `dopamine_lr`; only the trace → weight conversion is gated on it, which is
+    /// what lets reward arriving *after* a coincidence still pay for it.
+    ///
+    /// A coincidence is recorded once, on the step it happens — when the post
+    /// neuron fired now (`Δt = t_post − t_pre ≥ 0`, potentiation) or when the pre
+    /// channel fired now after an earlier post spike (`Δt < 0`, depression).
+    /// Re-applying the kernel every step from stale `last_spike_time` values
+    /// would inflate one spike pair into sustained learning.
     fn apply_stdp(&mut self, dopamine_lr: f32) {
-        if dopamine_lr < 1e-6 {
-            return;
-        }
-
-        let input_times = self.input_spike_times.clone();
+        let now = self.global_step;
+        let config = self.stdp_config;
+        let (w_min, w_max) = config.weight_bounds();
+        let rewarding = dopamine_lr >= 1e-6;
+        let input_times = &self.input_spike_times;
 
         for neuron in &mut self.neurons {
-            if neuron.last_spike_time < 0 {
-                continue;
+            // Pre-0.6 deserialized state carries no traces, and a caller may have
+            // resized `weights` by hand; keep the two vectors index-compatible.
+            if neuron.eligibility.len() != neuron.weights.len() {
+                neuron.eligibility.resize(
+                    neuron.weights.len(),
+                    EligibilityTrace::new(config.tau_eligibility),
+                );
             }
 
-            for (ch, &pre_time) in input_times.iter().enumerate() {
-                if ch >= neuron.weights.len() || pre_time < 0 {
-                    continue;
+            let post_time = neuron.last_spike_time;
+
+            for (ch, &pre_time) in input_times.iter().enumerate().take(neuron.weights.len()) {
+                let trace = &mut neuron.eligibility[ch];
+
+                // An untouched trace decays to itself; skip the `exp` so a blank
+                // or unrewarded network stays cheap at large channel counts.
+                if trace.value != 0.0 {
+                    trace.decay();
                 }
 
-                let post_time = neuron.last_spike_time;
-                if post_time < 0 {
-                    continue;
+                if pre_time >= 0
+                    && post_time >= 0
+                    && (post_time == now || (pre_time == now && post_time < pre_time))
+                {
+                    trace.accumulate((post_time - pre_time) as f32);
                 }
 
-                let delta_t = (post_time - pre_time) as f32;
-                let dw = if delta_t >= 0.0 {
-                    RM_STDP_A_PLUS * (-delta_t / RM_STDP_TAU_PLUS).exp()
-                } else {
-                    -RM_STDP_A_MINUS * (delta_t / RM_STDP_TAU_MINUS).exp()
-                };
-
-                neuron.weights[ch] =
-                    (neuron.weights[ch] + dw * dopamine_lr).clamp(RM_STDP_W_MIN, RM_STDP_W_MAX);
+                if rewarding && trace.value != 0.0 {
+                    let dw = config.reward_lr * dopamine_lr * trace.value;
+                    neuron.weights[ch] = (neuron.weights[ch] + dw).clamp(w_min, w_max);
+                }
             }
         }
     }
@@ -295,6 +361,9 @@ impl SpikingNetwork {
             neuron.membrane_potential = 0.0;
             neuron.last_spike = false;
             neuron.last_spike_time = -1;
+            for trace in &mut neuron.eligibility {
+                trace.reset();
+            }
         }
 
         self.modulators = NeuroModulators::default();
@@ -329,6 +398,12 @@ mod tests {
         assert_eq!(network.input_spike_times.len(), 518);
         assert_eq!(network.predictive_state.len(), 518);
         assert_eq!(network.neurons[0].weights.len(), 518);
+        assert_eq!(network.neurons[0].eligibility.len(), 518);
+        assert_eq!(network.stdp_config, RmStdpConfig::default());
+        assert_eq!(
+            network.neurons[0].eligibility[0].tau,
+            RmStdpConfig::default().tau_eligibility
+        );
     }
 
     #[test]
@@ -384,5 +459,340 @@ mod tests {
         for &p in &potentials {
             assert_eq!(p, 0.0);
         }
+    }
+
+    // --- Reward-gated STDP over eligibility traces (GH#72 / GH#73 / GH#74) ---
+
+    /// Four LIF neurons over four channels, weights seeded so the L1
+    /// renormalization pass in `step` is an exact no-op (`sum == WEIGHT_BUDGET`).
+    /// That isolates weight movement caused by learning from weight movement
+    /// caused by rescaling.
+    fn rstdp_test_network() -> SpikingNetwork {
+        const CHANNELS: usize = 4;
+        let mut network = SpikingNetwork::with_dimensions(4, 1, CHANNELS);
+        let seed = WEIGHT_BUDGET / CHANNELS as f32;
+        for neuron in &mut network.neurons {
+            neuron.weights = vec![seed; CHANNELS];
+        }
+        network
+    }
+
+    /// Channels 0 and 1 spike on every step (`|s| = 1.0` always wins the
+    /// Bernoulli trial); channels 2 and 3 never spike (`|s| <= 0.01` skips the
+    /// trial entirely). No RNG outcome is left to chance.
+    const DRIVEN_AND_SILENT: [f32; 4] = [1.0, 1.0, 0.0, 0.0];
+
+    #[test]
+    fn test_traces_accumulate_without_dopamine_but_weights_hold() {
+        let mut network = rstdp_test_network();
+        let before = network.neurons[0].weights.clone();
+        let no_reward = NeuroModulators::default();
+        assert_eq!(no_reward.dopamine, 0.0);
+
+        for _ in 0..25 {
+            network
+                .step(&DRIVEN_AND_SILENT, &no_reward)
+                .expect("length matches");
+        }
+
+        // Learning is gated off, so not one weight moved...
+        assert_eq!(network.neurons[0].weights, before);
+        // ...but the driven synapses still banked the coincidences.
+        assert!(
+            network.neurons[0].eligibility[0].value > 0.0,
+            "driven channel should hold a positive trace, got {}",
+            network.neurons[0].eligibility[0].value
+        );
+        assert_eq!(network.neurons[0].eligibility[2].value, 0.0);
+    }
+
+    #[test]
+    fn test_dopamine_converts_traces_into_weight_change() {
+        let mut network = rstdp_test_network();
+        let seed = network.neurons[0].weights[0];
+        let reward = NeuroModulators {
+            dopamine: 0.8,
+            ..Default::default()
+        };
+
+        for _ in 0..25 {
+            network
+                .step(&DRIVEN_AND_SILENT, &reward)
+                .expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            assert!(
+                neuron.weights[0] > seed && neuron.weights[1] > seed,
+                "driven synapses should potentiate: {:?}",
+                neuron.weights
+            );
+            assert!(
+                neuron.weights[2] < seed && neuron.weights[3] < seed,
+                "silent synapses should lose share of the L1 budget: {:?}",
+                neuron.weights
+            );
+            assert!(neuron.eligibility[0].value > 0.0);
+        }
+    }
+
+    #[test]
+    fn test_weight_change_scales_with_dopamine_level() {
+        let run = |dopamine: f32| {
+            let mut network = rstdp_test_network();
+            let modulators = NeuroModulators {
+                dopamine,
+                ..Default::default()
+            };
+            for _ in 0..25 {
+                network
+                    .step(&DRIVEN_AND_SILENT, &modulators)
+                    .expect("length matches");
+            }
+            network.neurons[0].weights[0]
+        };
+
+        let weak = run(0.2);
+        let strong = run(0.9);
+        assert!(
+            strong > weak,
+            "more dopamine must buy more learning: {strong} vs {weak}"
+        );
+    }
+
+    #[test]
+    fn test_reward_pays_out_the_banked_trace_not_just_the_latest_spike() {
+        let reward = NeuroModulators {
+            dopamine: 0.8,
+            ..Default::default()
+        };
+
+        // Bank ten steps of coincidences with reward switched off, then reward once.
+        let mut banked = rstdp_test_network();
+        let no_reward = NeuroModulators::default();
+        for _ in 0..10 {
+            banked
+                .step(&DRIVEN_AND_SILENT, &no_reward)
+                .expect("length matches");
+        }
+        let before_reward = banked.neurons[0].weights[0];
+        banked
+            .step(&DRIVEN_AND_SILENT, &reward)
+            .expect("length matches");
+        let banked_gain = banked.neurons[0].weights[0] - before_reward;
+
+        // Identical reward on an identical step, with nothing banked behind it.
+        let mut fresh = rstdp_test_network();
+        let fresh_seed = fresh.neurons[0].weights[0];
+        fresh
+            .step(&DRIVEN_AND_SILENT, &reward)
+            .expect("length matches");
+        let fresh_gain = fresh.neurons[0].weights[0] - fresh_seed;
+
+        assert!(banked_gain > 0.0 && fresh_gain > 0.0);
+        assert!(
+            banked_gain > 5.0 * fresh_gain,
+            "the accumulated trace, not the latest coincidence alone, must drive \
+             the update: {banked_gain} vs {fresh_gain}"
+        );
+    }
+
+    #[test]
+    fn test_trace_converts_on_a_step_with_no_new_coincidence() {
+        // Two channels, weights summing to the L1 budget so renormalization
+        // cannot manufacture the difference this test looks for.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![WEIGHT_BUDGET / 2.0; 2];
+        let seed = network.neurons[0].weights[0];
+        // Credit earned earlier, on steps this network has no memory of beyond
+        // the trace itself.
+        network.neurons[0].eligibility[0].value = 0.5;
+
+        // Zero stimuli: no pre spike is stamped, and with no drive (and no
+        // prediction error to be surprised by) the neuron cannot fire either.
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+        network.step(&[0.0, 0.0], &reward).expect("length matches");
+
+        assert_eq!(network.input_spike_times[0], -1, "no pre spike");
+        assert_eq!(network.neurons[0].last_spike_time, -1, "no post spike");
+        assert!(
+            network.neurons[0].eligibility[0].value < 0.5,
+            "the trace should have decayed, not grown"
+        );
+        assert!(
+            network.neurons[0].weights[0] > seed,
+            "deferred credit: reward converts the banked trace with no new spikes"
+        );
+        assert!(network.neurons[0].weights[0] > network.neurons[0].weights[1]);
+    }
+
+    #[test]
+    fn test_post_before_pre_drives_depression_and_respects_w_min() {
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        // Zero weights mean zero drive, so the neuron cannot fire and
+        // `last_spike_time` keeps the post spike we plant here — strictly before
+        // the pre spike that channel 0 emits on the step below.
+        network.neurons[0].weights = vec![0.0, 0.0];
+        network.neurons[0].last_spike_time = 0;
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        network.step(&[1.0, 0.0], &reward).expect("length matches");
+
+        assert_eq!(network.neurons[0].last_spike_time, 0, "must not have fired");
+        assert!(
+            network.neurons[0].eligibility[0].value < 0.0,
+            "post-before-pre is depression, got {}",
+            network.neurons[0].eligibility[0].value
+        );
+        assert_eq!(
+            network.neurons[0].weights[0],
+            network.stdp_config.weight_bounds().0,
+            "depression must clamp at w_min, not go negative"
+        );
+    }
+
+    #[test]
+    fn test_one_spike_pair_is_counted_once_not_re_accumulated() {
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 1);
+        network.neurons[0].weights = vec![0.0];
+        network.neurons[0].last_spike_time = 0;
+        let no_reward = NeuroModulators::default();
+
+        // Step 1 stamps a pre spike; the planted post spike at t=0 precedes it.
+        network.step(&[1.0], &no_reward).expect("length matches");
+        let after_event = network.neurons[0].eligibility[0].value;
+        assert!(after_event < 0.0);
+
+        // Step 2 has no stimulus, so neither side spikes: the stale pair must
+        // not be re-counted, leaving pure decay toward zero.
+        network.step(&[0.0], &no_reward).expect("length matches");
+        let after_quiet = network.neurons[0].eligibility[0].value;
+
+        assert!(
+            after_quiet > after_event && after_quiet < 0.0,
+            "expected decay toward zero, got {after_event} -> {after_quiet}"
+        );
+    }
+
+    #[test]
+    fn test_reset_clears_eligibility_traces() {
+        let mut network = rstdp_test_network();
+        let reward = NeuroModulators {
+            dopamine: 0.8,
+            ..Default::default()
+        };
+        for _ in 0..10 {
+            network
+                .step(&DRIVEN_AND_SILENT, &reward)
+                .expect("length matches");
+        }
+        assert!(network.neurons[0].eligibility[0].value > 0.0);
+
+        network.reset();
+
+        for neuron in &network.neurons {
+            assert!(neuron.eligibility.iter().all(|t| t.value == 0.0));
+            // `tau` survives a reset; only the accumulated value is cleared.
+            assert!(
+                neuron
+                    .eligibility
+                    .iter()
+                    .all(|t| t.tau == network.stdp_config.tau_eligibility)
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_rm_stdp_config_retaus_existing_traces() {
+        let mut network = rstdp_test_network();
+        let config = RmStdpConfig {
+            tau_eligibility: 100.0,
+            reward_lr: 0.02,
+            w_min: 0.1,
+            w_max: 1.5,
+        };
+
+        network.set_rm_stdp_config(config);
+
+        assert_eq!(network.stdp_config, config);
+        for neuron in &network.neurons {
+            assert!(neuron.eligibility.iter().all(|t| t.tau == 100.0));
+        }
+    }
+
+    #[test]
+    fn test_config_weight_bounds_are_enforced_by_step() {
+        let mut network = rstdp_test_network();
+        network.set_rm_stdp_config(RmStdpConfig {
+            w_max: 0.55,
+            ..RmStdpConfig::default()
+        });
+        let reward = NeuroModulators {
+            dopamine: 1.0,
+            ..Default::default()
+        };
+
+        for _ in 0..60 {
+            network
+                .step(&DRIVEN_AND_SILENT, &reward)
+                .expect("length matches");
+        }
+
+        for neuron in &network.neurons {
+            assert!(
+                neuron.weights.iter().all(|&w| w <= 0.55 + 1e-6),
+                "weights must respect the configured w_max: {:?}",
+                neuron.weights
+            );
+        }
+    }
+
+    #[test]
+    fn test_pre_0_6_state_without_new_fields_loads_and_steps() {
+        let mut network = SpikingNetwork::with_dimensions(2, 1, 3);
+        for neuron in &mut network.neurons {
+            neuron.weights = vec![0.4; 3];
+        }
+
+        // Strip the fields added in 0.6 to mimic a checkpoint written before
+        // eligibility traces were wired in.
+        let mut state = serde_json::to_value(&network).expect("network serializes");
+        let object = state.as_object_mut().expect("network is a JSON object");
+        object.remove("stdp_config");
+        for neuron in object["neurons"].as_array_mut().expect("neurons array") {
+            neuron
+                .as_object_mut()
+                .expect("neuron is a JSON object")
+                .remove("eligibility");
+        }
+
+        let mut restored: SpikingNetwork =
+            serde_json::from_value(state).expect("pre-0.6 state still deserializes");
+        assert!(restored.neurons[0].eligibility.is_empty());
+        assert_eq!(restored.stdp_config, RmStdpConfig::default());
+
+        let reward = NeuroModulators {
+            dopamine: 0.7,
+            ..Default::default()
+        };
+        for _ in 0..5 {
+            restored
+                .step(&[0.9, 0.9, 0.9], &reward)
+                .expect("length matches");
+        }
+
+        assert_eq!(restored.neurons[0].eligibility.len(), 3);
+        assert!(
+            restored.neurons[0]
+                .eligibility
+                .iter()
+                .all(|t| t.tau == RmStdpConfig::default().tau_eligibility)
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -360,9 +360,18 @@ impl SpikingNetwork {
             for (ch, &pre_time) in input_times.iter().enumerate().take(neuron.weights.len()) {
                 let trace = &mut neuron.eligibility[ch];
 
-                // An untouched trace decays to itself; skip the `exp` so a blank
-                // or unrewarded network stays cheap at large channel counts.
-                if trace.value != 0.0 {
+                // A non-finite trace carries no credit, and paying it out would
+                // poison the weight — `clamp` preserves NaN, and the L1 pass then
+                // skips this neuron forever because a NaN total is never
+                // `> 1e-6`. Clear it so the synapse can learn again. `value` is
+                // public and deserializable, so this is reachable without ever
+                // going through `accumulate`.
+                if !trace.value.is_finite() {
+                    trace.reset();
+                } else if trace.value != 0.0 {
+                    // An untouched trace decays to itself; skip the `exp` so a
+                    // blank or unrewarded network stays cheap at large channel
+                    // counts.
                     trace.decay();
                 }
 
@@ -953,6 +962,37 @@ mod tests {
                 RmStdpConfig::default().tau_eligibility
             );
         }
+    }
+
+    #[test]
+    fn test_non_finite_trace_value_cannot_poison_weights() {
+        // `EligibilityTrace::value` is public and deserializable, so a NaN can
+        // arrive without ever passing through `accumulate`.
+        let mut network = SpikingNetwork::with_dimensions(1, 1, 2);
+        network.neurons[0].weights = vec![1.0, 1.0];
+        network.neurons[0].eligibility[0].value = f32::NAN;
+        network.neurons[0].eligibility[1].value = f32::INFINITY;
+        let reward = NeuroModulators {
+            dopamine: 0.9,
+            ..Default::default()
+        };
+
+        for _ in 0..5 {
+            network.step(&[1.0, 1.0], &reward).expect("length matches");
+        }
+
+        assert!(
+            network.neurons[0].weights.iter().all(|w| w.is_finite()),
+            "a non-finite trace must not poison weights: {:?}",
+            network.neurons[0].weights
+        );
+        assert!(
+            network.neurons[0]
+                .eligibility
+                .iter()
+                .all(|t| t.value.is_finite()),
+            "the trace itself should be cleared, not left non-finite"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 //! 2. [`engine`] — [`SpikingNetwork`] and the per-tick [`SpikingNetwork::step`] contract.
 //! 3. [`lif`] / [`izhikevich`] — the two banks the engine actually wires.
 //! 4. [`modulators`] — dopamine / serotonin / acetylcholine / norepinephrine.
-//! 5. [`rm_stdp`] / [`hebbian`] — plasticity building blocks (eligibility traces are
-//!    **not** yet consumed by the live engine path; see those modules).
+//! 5. [`rm_stdp`] / [`hebbian`] — plasticity: reward-modulated eligibility traces
+//!    (wired into the engine) and classical Hebbian STDP (standalone).
 //! 6. Standalone models ([`lapicque`], [`gif`], [`fitzhugh_nagumo`], [`hodgkin_huxley`])
 //!    for research use outside the engine.
 //!
@@ -32,14 +32,17 @@
 //! - **Standalone** types (`LapicqueNeuron`, `GifNeuron`, `FitzHughNagumoNeuron`,
 //!   `HodgkinHuxleyNeuron`, …) are usable on their own; they are not alternate
 //!   engine banks.
-//! - Plasticity: classical Hebbian STDP utilities plus `EligibilityTrace` /
-//!   `RmStdpConfig` building blocks. Live `step` learning is dopamine-gated and
-//!   updates LIF weights **directly** (not via eligibility conversion).
+//! - Plasticity: `SpikingNetwork` learns through `EligibilityTrace` / `RmStdpConfig`.
+//!   Each step decays and accumulates one trace per synapse regardless of dopamine;
+//!   dopamine gates only the trace → weight conversion, so reward can arrive after
+//!   the coincidence it pays for. Classical Hebbian STDP utilities are separate and
+//!   unmodulated.
 //!
 //! ## Features
 //!
 //! - Topology-neutral, dynamically sized `SpikingNetwork`
 //! - Neuromodulators: dopamine, serotonin, acetylcholine, norepinephrine
+//! - Reward-modulated STDP over per-synapse eligibility traces
 //!
 //! ```rust
 //! use neuromod::{NeuroModulators, SpikingNetwork};

--- a/src/lif.rs
+++ b/src/lif.rs
@@ -2,8 +2,9 @@
 //!
 //! Primary bank of [`crate::SpikingNetwork`]: each [`LifNeuron`] has a membrane
 //! potential, threshold, decay, and a vector of synaptic weights (one per input
-//! channel). The engine integrates, fires, applies lateral inhibition, and
-//! runs dopamine-gated STDP on these weights.
+//! channel), each weight paired with an [`EligibilityTrace`]. The engine
+//! integrates, fires, applies lateral inhibition, then decays and accumulates
+//! the traces and converts them into weight changes under a dopamine gate.
 //!
 //! [`PoissonEncoder`] is a small helper that turns a scalar intensity into a
 //! binary spike train (Bernoulli trials). It is **not** required by
@@ -15,6 +16,8 @@
 
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
+
+use crate::rm_stdp::EligibilityTrace;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PoissonEncoder {
@@ -81,6 +84,16 @@ pub struct LifNeuron {
     /// Uses a global step counter maintained by the engine.
     #[serde(default)]
     pub last_spike_time: i64,
+    /// Per-synapse eligibility traces — one per input channel, indexed exactly
+    /// like [`Self::weights`].
+    ///
+    /// The engine decays these every step and accumulates a pre/post
+    /// coincidence on the step a spike occurs, then converts them into weight
+    /// changes when dopamine is present. Empty on a neuron built outside the
+    /// engine (and on pre-0.6 deserialized state); the engine resizes it to
+    /// match `weights` before use.
+    #[serde(default)]
+    pub eligibility: Vec<EligibilityTrace>,
 }
 
 impl Default for LifNeuron {
@@ -93,6 +106,7 @@ impl Default for LifNeuron {
             last_spike: false,
             weights: Vec::new(),
             last_spike_time: -1,
+            eligibility: Vec::new(),
         }
     }
 }
@@ -141,6 +155,7 @@ mod tests {
         assert!(!neuron.last_spike);
         assert!(neuron.weights.is_empty());
         assert_eq!(neuron.last_spike_time, -1);
+        assert!(neuron.eligibility.is_empty());
     }
 
     #[test]

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -1,18 +1,28 @@
 //! R-STDP (Reward-modulated Spike-Timing-Dependent Plasticity) parameters.
 //!
-//! This module holds R-STDP constants, `RmStdpConfig`, and a standalone
-//! [`EligibilityTrace`] building block for standalone use.
+//! This module holds the R-STDP constants, [`RmStdpConfig`], and the
+//! [`EligibilityTrace`] building block that the engine learns through.
 //!
-//! **Live engine path:** `SpikingNetwork::apply_stdp` in `src/engine.rs` is
-//! dopamine-gated and updates weights directly from spike timing. It does
-//! **not** currently consume or convert `EligibilityTrace` values.
+//! R-STDP in one sentence: an eligibility trace accumulates a "memory" of
+//! recent pre/post spike-timing coincidences, then a reward signal (dopamine)
+//! converts that trace into a weight change.
 //!
-//! Idealized R-STDP (not yet wired in-engine): an eligibility trace accumulates
-//! a "memory" of recent pre/post spike-timing coincidences, then a reward
-//! signal (dopamine) converts that trace into a weight change.
+//! **Live engine path:** `SpikingNetwork::apply_stdp` (`src/engine.rs`) keeps
+//! one [`EligibilityTrace`] per synapse in [`crate::LifNeuron::eligibility`]. Every
+//! step it decays each trace and accumulates a coincidence on the step where the
+//! post neuron or the pre channel actually spiked — **regardless of dopamine**.
+//! Only the trace → weight conversion is dopamine-gated. Weight updates therefore
+//! flow *through* the trace, not around it, so a coincidence recorded during a
+//! reward-free step can still be paid out when reward arrives later.
+//!
+//! Decision record (wire, not demote): [ADR 002][adr].
+//!
+//! [adr]: https://github.com/Limen-Neural/neuromod/blob/main/docs/adr/002-wire-eligibility-traces.md
 //!
 //! ANALOGY: Hebb's Rule on a timer — "neurons that fire together wire
-//! together," but only if the timing (and, eventually, reward) is right.
+//! together," but only if the timing *and* the reward are right.
+
+use serde::{Deserialize, Serialize};
 
 /// LTP (potentiation) time constant, in steps.
 pub const RM_STDP_TAU_PLUS: f32 = 20.0;
@@ -26,15 +36,43 @@ pub const RM_STDP_A_MINUS: f32 = 0.012;
 pub const RM_STDP_W_MIN: f32 = 0.0;
 /// Maximum synaptic weight (prevents runaway excitation).
 pub const RM_STDP_W_MAX: f32 = 2.0;
+/// Default eligibility-trace decay time constant, in steps.
+///
+/// Longer than the LTP/LTD kernels ([`RM_STDP_TAU_PLUS`] / [`RM_STDP_TAU_MINUS`]):
+/// the kernel decides *how much* credit a coincidence earns, the trace decides
+/// *how long* that credit stays claimable before reward arrives.
+pub const RM_STDP_TAU_ELIGIBILITY: f32 = 50.0;
+/// Default learning rate for converting an eligibility trace into a weight change.
+pub const RM_STDP_REWARD_LR: f32 = 0.05;
 
 const _: () = assert!(RM_STDP_W_MIN < RM_STDP_W_MAX);
 const _: () = assert!(RM_STDP_A_MINUS >= RM_STDP_A_PLUS);
+const _: () = assert!(RM_STDP_TAU_ELIGIBILITY > 0.0);
+const _: () = assert!(RM_STDP_REWARD_LR > 0.0);
 
 /// Eligibility trace for a single synapse.
 ///
-/// Accumulates based on pre/post spike timing and decays exponentially over
-/// time; positive values favor potentiation (LTP), negative values favor
-/// depression (LTD). Each synapse holds its own trace instance.
+/// Accumulates on pre/post spike timing and decays exponentially over time;
+/// positive values favor potentiation (LTP), negative values favor depression
+/// (LTD). Each synapse holds its own trace instance — the engine keeps one per
+/// input channel in [`crate::LifNeuron::eligibility`].
+///
+/// ```
+/// use neuromod::EligibilityTrace;
+///
+/// let mut trace = EligibilityTrace::new(50.0);
+/// assert_eq!(trace.value, 0.0);
+///
+/// // Pre fired one step before post: potentiation.
+/// trace.accumulate(1.0);
+/// assert!(trace.value > 0.0);
+///
+/// // The imprint fades unless reward converts it into a weight change.
+/// let peak = trace.value;
+/// trace.decay();
+/// assert!(trace.value < peak);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct EligibilityTrace {
     /// Current trace value.
     pub value: f32,
@@ -42,7 +80,18 @@ pub struct EligibilityTrace {
     pub tau: f32,
 }
 
+impl Default for EligibilityTrace {
+    fn default() -> Self {
+        Self::new(RM_STDP_TAU_ELIGIBILITY)
+    }
+}
+
 /// R-STDP hyperparameters.
+///
+/// Held by `SpikingNetwork::stdp_config`; see
+/// [`SpikingNetwork::set_rm_stdp_config`](crate::SpikingNetwork::set_rm_stdp_config)
+/// to change it on a live network.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RmStdpConfig {
     /// Eligibility trace decay time constant, in steps. Typical values are 50-100.
     pub tau_eligibility: f32,
@@ -55,7 +104,76 @@ pub struct RmStdpConfig {
     pub w_max: f32,
 }
 
+impl Default for RmStdpConfig {
+    fn default() -> Self {
+        Self {
+            tau_eligibility: RM_STDP_TAU_ELIGIBILITY,
+            reward_lr: RM_STDP_REWARD_LR,
+            w_min: RM_STDP_W_MIN,
+            w_max: RM_STDP_W_MAX,
+        }
+    }
+}
+
+impl RmStdpConfig {
+    /// Weight bounds as an ordered `(min, max)` pair, safe to hand to
+    /// [`f32::clamp`].
+    ///
+    /// `w_min` and `w_max` are public fields, so a caller can leave them
+    /// reversed or non-finite — which would make `clamp` panic. This falls back
+    /// to [`RM_STDP_W_MIN`] / [`RM_STDP_W_MAX`] in that case rather than taking
+    /// the engine down mid-step.
+    ///
+    /// ```
+    /// use neuromod::RmStdpConfig;
+    ///
+    /// let sane = RmStdpConfig { w_min: 0.2, w_max: 1.5, ..RmStdpConfig::default() };
+    /// assert_eq!(sane.weight_bounds(), (0.2, 1.5));
+    ///
+    /// let reversed = RmStdpConfig { w_min: 1.5, w_max: 0.2, ..RmStdpConfig::default() };
+    /// assert_eq!(reversed.weight_bounds(), (0.0, 2.0));
+    /// ```
+    pub fn weight_bounds(&self) -> (f32, f32) {
+        if !self.w_min.is_finite() || !self.w_max.is_finite() || self.w_min > self.w_max {
+            return (RM_STDP_W_MIN, RM_STDP_W_MAX);
+        }
+        (self.w_min, self.w_max)
+    }
+}
+
 impl EligibilityTrace {
+    /// Create a zeroed trace with decay time constant `tau` (in steps).
+    pub const fn new(tau: f32) -> Self {
+        Self { value: 0.0, tau }
+    }
+
+    /// Spike-timing kernel for one pre/post coincidence, with
+    /// `delta_t = t_post - t_pre` measured in steps.
+    ///
+    /// - `delta_t >= 0` (pre fired first, and so may have caused the post
+    ///   spike): potentiation, `+A₊·exp(−Δt/τ₊)`.
+    /// - `delta_t < 0` (post fired first, so pre cannot have caused it):
+    ///   depression, `−A₋·exp(Δt/τ₋)`.
+    ///
+    /// Magnitude is largest at `delta_t == 0` and falls off exponentially as
+    /// the two spikes drift apart.
+    pub fn kernel(delta_t: f32) -> f32 {
+        if delta_t >= 0.0 {
+            RM_STDP_A_PLUS * (-delta_t / RM_STDP_TAU_PLUS).exp()
+        } else {
+            -RM_STDP_A_MINUS * (delta_t / RM_STDP_TAU_MINUS).exp()
+        }
+    }
+
+    /// Record one pre/post coincidence, adding [`Self::kernel`] to the trace.
+    ///
+    /// Call this only on a step where a spike actually occurred. Re-applying it
+    /// every step from a stale spike pair inflates the trace toward
+    /// `tau × kernel` and turns one coincidence into sustained learning.
+    pub fn accumulate(&mut self, delta_t: f32) {
+        self.value += Self::kernel(delta_t);
+    }
+
     /// Decay the trace by one step (assumes dt = 1 unit).
     pub fn decay(&mut self) {
         // Guard against non-positive tau, which would cause division by zero
@@ -63,11 +181,130 @@ impl EligibilityTrace {
         let tau = self.tau.max(f32::EPSILON);
         self.value *= (-1.0 / tau).exp();
     }
+
+    /// Clear the accumulated value, keeping [`Self::tau`].
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn new_starts_at_zero_with_requested_tau() {
+        let trace = EligibilityTrace::new(75.0);
+        assert_eq!(trace.value, 0.0);
+        assert_eq!(trace.tau, 75.0);
+    }
+
+    #[test]
+    fn default_trace_uses_default_eligibility_tau() {
+        let trace = EligibilityTrace::default();
+        assert_eq!(trace.value, 0.0);
+        assert_eq!(trace.tau, RM_STDP_TAU_ELIGIBILITY);
+    }
+
+    #[test]
+    fn default_config_matches_published_constants() {
+        let config = RmStdpConfig::default();
+        assert_eq!(config.tau_eligibility, RM_STDP_TAU_ELIGIBILITY);
+        assert_eq!(config.reward_lr, RM_STDP_REWARD_LR);
+        assert_eq!(config.w_min, RM_STDP_W_MIN);
+        assert_eq!(config.w_max, RM_STDP_W_MAX);
+    }
+
+    #[test]
+    fn weight_bounds_pass_through_a_sane_configuration() {
+        let config = RmStdpConfig {
+            w_min: 0.25,
+            w_max: 1.75,
+            ..RmStdpConfig::default()
+        };
+        assert_eq!(config.weight_bounds(), (0.25, 1.75));
+    }
+
+    #[test]
+    fn weight_bounds_fall_back_when_reversed_or_non_finite() {
+        let fallback = (RM_STDP_W_MIN, RM_STDP_W_MAX);
+        for (w_min, w_max) in [
+            (1.5, 0.2),
+            (f32::NAN, 1.0),
+            (0.0, f32::NAN),
+            (f32::NEG_INFINITY, f32::INFINITY),
+        ] {
+            let config = RmStdpConfig {
+                w_min,
+                w_max,
+                ..RmStdpConfig::default()
+            };
+            let (lo, hi) = config.weight_bounds();
+            assert_eq!((lo, hi), fallback);
+            // The contract that matters: `clamp` must not panic on the result.
+            assert!(0.5_f32.clamp(lo, hi).is_finite());
+        }
+    }
+
+    #[test]
+    fn kernel_potentiates_when_pre_precedes_post() {
+        let dw = EligibilityTrace::kernel(5.0);
+        assert!(dw > 0.0);
+        let expected = RM_STDP_A_PLUS * (-5.0_f32 / RM_STDP_TAU_PLUS).exp();
+        assert!((dw - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn kernel_depresses_when_post_precedes_pre() {
+        let dw = EligibilityTrace::kernel(-5.0);
+        assert!(dw < 0.0);
+        let expected = -RM_STDP_A_MINUS * (-5.0_f32 / RM_STDP_TAU_MINUS).exp();
+        assert!((dw - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn kernel_is_strongest_at_coincident_spikes() {
+        assert!((EligibilityTrace::kernel(0.0) - RM_STDP_A_PLUS).abs() < 1e-9);
+        assert!(EligibilityTrace::kernel(1.0) < EligibilityTrace::kernel(0.0));
+        assert!(EligibilityTrace::kernel(20.0) < EligibilityTrace::kernel(1.0));
+        assert!(EligibilityTrace::kernel(-1.0) > EligibilityTrace::kernel(-0.5));
+    }
+
+    #[test]
+    fn accumulate_adds_the_kernel_to_the_trace() {
+        let mut trace = EligibilityTrace::new(50.0);
+        trace.accumulate(3.0);
+        assert!((trace.value - EligibilityTrace::kernel(3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn accumulate_compounds_repeated_coincidences() {
+        let mut trace = EligibilityTrace::new(50.0);
+        trace.accumulate(0.0);
+        let after_first = trace.value;
+        trace.accumulate(0.0);
+        assert!(trace.value > after_first);
+        assert!((trace.value - 2.0 * RM_STDP_A_PLUS).abs() < 1e-9);
+    }
+
+    #[test]
+    fn accumulate_can_flip_a_potentiated_trace_negative() {
+        let mut trace = EligibilityTrace::new(50.0);
+        trace.accumulate(0.0);
+        assert!(trace.value > 0.0);
+        // LTD amplitude exceeds LTP amplitude, so a coincident depression wins.
+        trace.accumulate(-0.0001);
+        assert!(trace.value < 0.0);
+    }
+
+    #[test]
+    fn reset_clears_value_but_keeps_tau() {
+        let mut trace = EligibilityTrace::new(60.0);
+        trace.accumulate(0.0);
+        trace.reset();
+        assert_eq!(trace.value, 0.0);
+        assert_eq!(trace.tau, 60.0);
+    }
 
     #[test]
     fn decay_scales_value_by_exp_neg_inv_tau() {

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -105,6 +105,12 @@ pub struct RmStdpConfig {
     /// when a reward signal arrives. Typical values are 0.01-0.1.
     pub reward_lr: f32,
     /// Minimum weight (no negative/inhibitory weights yet).
+    ///
+    /// Bounds weight *updates* — the clamp in `apply_stdp` and the L1
+    /// renormalization pass. It is not a floor imposed on untouched weights: a
+    /// network starts with blank (zero) weights by design, and renormalization
+    /// skips a neuron whose weights still sum to ~0, so a positive `w_min`
+    /// never seeds one.
     pub w_min: f32,
     /// Maximum weight (prevents runaway excitation).
     pub w_max: f32,
@@ -144,6 +150,34 @@ impl RmStdpConfig {
             return (RM_STDP_W_MIN, RM_STDP_W_MAX);
         }
         (self.w_min, self.w_max)
+    }
+
+    /// Reward learning rate, guarded against a non-finite value.
+    ///
+    /// `reward_lr` is public too, and a `NaN` rate is worse than a bad clamp: it
+    /// poisons a weight on the first rewarded step, and the L1 renormalization
+    /// pass then skips that neuron forever, because a `NaN` total is not
+    /// `> 1e-6`. The corruption would never clear. Falls back to
+    /// [`RM_STDP_REWARD_LR`].
+    ///
+    /// A finite negative rate is passed through — inverting the sign of learning
+    /// is a legitimate (if unusual) choice, unlike `NaN`.
+    ///
+    /// ```
+    /// use neuromod::RmStdpConfig;
+    ///
+    /// let poisoned = RmStdpConfig { reward_lr: f32::NAN, ..RmStdpConfig::default() };
+    /// assert_eq!(poisoned.effective_reward_lr(), 0.05);
+    ///
+    /// let tuned = RmStdpConfig { reward_lr: 0.02, ..RmStdpConfig::default() };
+    /// assert_eq!(tuned.effective_reward_lr(), 0.02);
+    /// ```
+    pub fn effective_reward_lr(&self) -> f32 {
+        if self.reward_lr.is_finite() {
+            self.reward_lr
+        } else {
+            RM_STDP_REWARD_LR
+        }
     }
 }
 
@@ -249,6 +283,28 @@ mod tests {
             assert_eq!((lo, hi), fallback);
             // The contract that matters: `clamp` must not panic on the result.
             assert!(0.5_f32.clamp(lo, hi).is_finite());
+        }
+    }
+
+    #[test]
+    fn effective_reward_lr_passes_through_finite_rates() {
+        for rate in [0.0, 0.02, RM_STDP_REWARD_LR, -0.03] {
+            let config = RmStdpConfig {
+                reward_lr: rate,
+                ..RmStdpConfig::default()
+            };
+            assert_eq!(config.effective_reward_lr(), rate);
+        }
+    }
+
+    #[test]
+    fn effective_reward_lr_falls_back_for_non_finite_rates() {
+        for rate in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let config = RmStdpConfig {
+                reward_lr: rate,
+                ..RmStdpConfig::default()
+            };
+            assert_eq!(config.effective_reward_lr(), RM_STDP_REWARD_LR);
         }
     }
 

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -179,6 +179,33 @@ impl RmStdpConfig {
             RM_STDP_REWARD_LR
         }
     }
+
+    /// Eligibility time constant, guarded against a non-finite or non-positive
+    /// value.
+    ///
+    /// Both failure modes are silent rather than loud: a `NaN` tau degrades
+    /// [`EligibilityTrace::decay`] to `exp(-1/f32::EPSILON) == 0`, erasing every
+    /// banked trace on the next step, and `+∞` gives `exp(-0) == 1`, disabling
+    /// decay altogether. Either falls back to [`RM_STDP_TAU_ELIGIBILITY`].
+    ///
+    /// ```
+    /// use neuromod::RmStdpConfig;
+    ///
+    /// let slow = RmStdpConfig { tau_eligibility: 200.0, ..RmStdpConfig::default() };
+    /// assert_eq!(slow.effective_tau_eligibility(), 200.0);
+    ///
+    /// for bad in [f32::NAN, f32::INFINITY, 0.0, -10.0] {
+    ///     let config = RmStdpConfig { tau_eligibility: bad, ..RmStdpConfig::default() };
+    ///     assert_eq!(config.effective_tau_eligibility(), 50.0);
+    /// }
+    /// ```
+    pub fn effective_tau_eligibility(&self) -> f32 {
+        if self.tau_eligibility.is_finite() && self.tau_eligibility > 0.0 {
+            self.tau_eligibility
+        } else {
+            RM_STDP_TAU_ELIGIBILITY
+        }
+    }
 }
 
 impl EligibilityTrace {
@@ -215,10 +242,18 @@ impl EligibilityTrace {
     }
 
     /// Decay the trace by one step (assumes dt = 1 unit).
+    ///
+    /// A non-finite or non-positive `tau` falls back to
+    /// [`RM_STDP_TAU_ELIGIBILITY`]. Clamping to `f32::EPSILON` instead would
+    /// make `NaN` erase the trace outright (`exp(-1/ε) == 0`), and `+∞` would
+    /// leave `exp(-0) == 1`, disabling decay — both silent corruptions of
+    /// banked credit rather than honest degradation.
     pub fn decay(&mut self) {
-        // Guard against non-positive tau, which would cause division by zero
-        // or exponential growth instead of decay.
-        let tau = self.tau.max(f32::EPSILON);
+        let tau = if self.tau.is_finite() && self.tau > 0.0 {
+            self.tau
+        } else {
+            RM_STDP_TAU_ELIGIBILITY
+        };
         self.value *= (-1.0 / tau).exp();
     }
 
@@ -406,6 +441,25 @@ mod tests {
         };
         trace.decay();
         assert!(trace.value < 0.0);
+    }
+
+    #[test]
+    fn decay_with_non_finite_tau_falls_back_to_the_default() {
+        let expected = (-1.0_f32 / RM_STDP_TAU_ELIGIBILITY).exp();
+        for bad_tau in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 0.0, -10.0] {
+            let mut trace = EligibilityTrace {
+                value: 1.0,
+                tau: bad_tau,
+            };
+            trace.decay();
+            assert!(
+                (trace.value - expected).abs() < 1e-6,
+                "tau {bad_tau} should decay at the default rate, got {}",
+                trace.value
+            );
+            // Neither erased outright nor frozen in place.
+            assert!(trace.value > 0.0 && trace.value < 1.0);
+        }
     }
 
     #[test]

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -203,10 +203,16 @@ impl RmStdpConfig {
     /// Eligibility time constant, guarded against a non-finite or non-positive
     /// value.
     ///
-    /// Both failure modes are silent rather than loud: a `NaN` tau degrades
-    /// [`EligibilityTrace::decay`] to `exp(-1/f32::EPSILON) == 0`, erasing every
-    /// banked trace on the next step, and `+∞` gives `exp(-0) == 1`, disabling
-    /// decay altogether. Either falls back to [`RM_STDP_TAU_ELIGIBILITY`].
+    /// Every rejected value fails silently rather than loudly. Left unguarded,
+    /// [`EligibilityTrace::decay`] multiplies by `exp(-1/tau)`, so `NaN`
+    /// propagates (`-1/NaN` is `NaN`, `exp(NaN)` is `NaN`) and poisons the
+    /// banked value; `+∞` gives `exp(-0) == 1`, disabling decay altogether;
+    /// `0.0` gives `exp(-∞) == 0`, erasing every banked trace at once; and a
+    /// negative tau gives `exp(1/|tau|) > 1`, growing the trace without bound.
+    /// Each falls back to [`RM_STDP_TAU_ELIGIBILITY`].
+    ///
+    /// A *tiny positive* tau is not rejected: it is a legitimate setting that
+    /// means "no memory", and it does erase the trace within a step.
     ///
     /// ```
     /// use neuromod::RmStdpConfig;
@@ -242,8 +248,12 @@ impl EligibilityTrace {
     /// - `delta_t < 0` (post fired first, so pre cannot have caused it):
     ///   depression, `−A₋·exp(Δt/τ₋)`.
     ///
-    /// Magnitude is largest at `delta_t == 0` and falls off exponentially as
-    /// the two spikes drift apart.
+    /// Each branch peaks at its own zero boundary and falls off exponentially
+    /// as the two spikes drift apart: `A₊` at `Δt == 0`, and `A₋` as `Δt`
+    /// approaches zero from below. The two peaks are deliberately unequal —
+    /// [`RM_STDP_A_MINUS`] exceeds [`RM_STDP_A_PLUS`], the usual asymmetry that
+    /// makes uncorrelated pairs net-depressing — so the largest magnitude the
+    /// kernel returns is on the depression side, not at `Δt == 0`.
     ///
     /// A non-finite `delta_t` yields `0.0` — no usable timing means no credit.
     /// The engine cannot produce one (it subtracts two `i64` step counters), but
@@ -273,10 +283,12 @@ impl EligibilityTrace {
     /// Decay the trace by one step (assumes dt = 1 unit).
     ///
     /// A non-finite or non-positive `tau` falls back to
-    /// [`RM_STDP_TAU_ELIGIBILITY`]. Clamping to `f32::EPSILON` instead would
-    /// make `NaN` erase the trace outright (`exp(-1/ε) == 0`), and `+∞` would
-    /// leave `exp(-0) == 1`, disabling decay — both silent corruptions of
-    /// banked credit rather than honest degradation.
+    /// [`RM_STDP_TAU_ELIGIBILITY`] rather than being used as-is: `NaN` would
+    /// propagate into the banked value, `+∞` would leave `exp(-0) == 1` and
+    /// disable decay, `0.0` would erase the trace outright, and a negative tau
+    /// would grow it without bound — all silent corruptions of banked credit
+    /// rather than honest degradation. See
+    /// [`RmStdpConfig::effective_tau_eligibility`].
     pub fn decay(&mut self) {
         let tau = if self.tau.is_finite() && self.tau > 0.0 {
             self.tau

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -91,6 +91,12 @@ impl Default for EligibilityTrace {
 /// Held by `SpikingNetwork::stdp_config`; see
 /// [`SpikingNetwork::set_rm_stdp_config`](crate::SpikingNetwork::set_rm_stdp_config)
 /// to change it on a live network.
+///
+/// `w_min` / `w_max` take precedence over the engine's L1 weight budget: the
+/// renormalization pass in `step` scales toward the budget and then clamps, so
+/// narrowing this range leaves each neuron's weight sum off budget by however
+/// much the clamp binds. The defaults cannot bind (weights are non-negative and
+/// `w_max` equals the budget), so the budget holds exactly under them.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RmStdpConfig {
     /// Eligibility trace decay time constant, in steps. Typical values are 50-100.

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -133,13 +133,21 @@ impl Default for RmStdpConfig {
 }
 
 impl RmStdpConfig {
-    /// Weight bounds as an ordered `(min, max)` pair, safe to hand to
-    /// [`f32::clamp`].
+    /// Weight bounds as an ordered, non-negative `(min, max)` pair, safe to hand
+    /// to [`f32::clamp`].
     ///
-    /// `w_min` and `w_max` are public fields, so a caller can leave them
-    /// reversed or non-finite — which would make `clamp` panic. This falls back
-    /// to [`RM_STDP_W_MIN`] / [`RM_STDP_W_MAX`] in that case rather than taking
-    /// the engine down mid-step.
+    /// `w_min` and `w_max` are public fields, so a caller can leave them in
+    /// three states the engine cannot honor. Each falls back to
+    /// [`RM_STDP_W_MIN`] / [`RM_STDP_W_MAX`]:
+    ///
+    /// - **Non-finite** — `clamp` panics on a `NaN` bound, inside a
+    ///   `Result`-returning `step`.
+    /// - **Reversed** (`w_min > w_max`) — `clamp` panics on that too.
+    /// - **Negative `w_min`** — this crate does not support inhibitory weights
+    ///   (see [`RM_STDP_W_MIN`]). A negative floor lets a rewarded depression
+    ///   drive a synapse below zero, flipping its sign during integration, and
+    ///   once a neuron's weights sum negative the L1 renormalization pass skips
+    ///   it forever — its `total > 1e-6` guard is never true again.
     ///
     /// ```
     /// use neuromod::RmStdpConfig;
@@ -149,9 +157,16 @@ impl RmStdpConfig {
     ///
     /// let reversed = RmStdpConfig { w_min: 1.5, w_max: 0.2, ..RmStdpConfig::default() };
     /// assert_eq!(reversed.weight_bounds(), (0.0, 2.0));
+    ///
+    /// let inhibitory = RmStdpConfig { w_min: -2.0, w_max: -1.0, ..RmStdpConfig::default() };
+    /// assert_eq!(inhibitory.weight_bounds(), (0.0, 2.0));
     /// ```
     pub fn weight_bounds(&self) -> (f32, f32) {
-        if !self.w_min.is_finite() || !self.w_max.is_finite() || self.w_min > self.w_max {
+        if !self.w_min.is_finite()
+            || !self.w_max.is_finite()
+            || self.w_min < RM_STDP_W_MIN
+            || self.w_min > self.w_max
+        {
             return (RM_STDP_W_MIN, RM_STDP_W_MAX);
         }
         (self.w_min, self.w_max)
@@ -313,6 +328,9 @@ mod tests {
             (f32::NAN, 1.0),
             (0.0, f32::NAN),
             (f32::NEG_INFINITY, f32::INFINITY),
+            // Inhibitory ranges: ordered and finite, but unsupported.
+            (-2.0, -1.0),
+            (-0.5, 2.0),
         ] {
             let config = RmStdpConfig {
                 w_min,

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -244,7 +244,16 @@ impl EligibilityTrace {
     ///
     /// Magnitude is largest at `delta_t == 0` and falls off exponentially as
     /// the two spikes drift apart.
+    ///
+    /// A non-finite `delta_t` yields `0.0` — no usable timing means no credit.
+    /// The engine cannot produce one (it subtracts two `i64` step counters), but
+    /// this is public API, and `NaN` would otherwise take the depression branch
+    /// (`NaN >= 0.0` is false) and poison the trace it lands in. `±∞` already
+    /// degrade to zero through `exp`.
     pub fn kernel(delta_t: f32) -> f32 {
+        if !delta_t.is_finite() {
+            return 0.0;
+        }
         if delta_t >= 0.0 {
             RM_STDP_A_PLUS * (-delta_t / RM_STDP_TAU_PLUS).exp()
         } else {
@@ -395,6 +404,20 @@ mod tests {
         let mut trace = EligibilityTrace::new(50.0);
         trace.accumulate(3.0);
         assert!((trace.value - EligibilityTrace::kernel(3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn kernel_yields_no_credit_for_non_finite_timing() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(EligibilityTrace::kernel(bad), 0.0, "kernel({bad})");
+
+            let mut trace = EligibilityTrace::new(50.0);
+            trace.accumulate(bad);
+            assert_eq!(
+                trace.value, 0.0,
+                "accumulate({bad}) must not poison the trace"
+            );
+        }
     }
 
     #[test]

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -211,6 +211,16 @@ impl RmStdpConfig {
     /// negative tau gives `exp(1/|tau|) > 1`, growing the trace without bound.
     /// Each falls back to [`RM_STDP_TAU_ELIGIBILITY`].
     ///
+    /// [`EligibilityTrace::decay`] applies the same fallback to its own `tau`
+    /// field, so none of the above can actually reach the arithmetic. The two
+    /// guards cover different layers: `decay` protects a trace that already
+    /// holds a bad `tau`, while this accessor protects the value that *becomes*
+    /// one — `tau_eligibility` seeds every newly resized trace and is stamped
+    /// onto all of them by
+    /// [`SpikingNetwork::set_rm_stdp_config`](crate::SpikingNetwork::set_rm_stdp_config).
+    /// Guarding here keeps the stored `tau` correct and inspectable instead of
+    /// leaving each decay to paper over it.
+    ///
     /// A *tiny positive* tau is not rejected: it is a legitimate setting that
     /// means "no memory", and it does erase the trace within a step.
     ///

--- a/src/rm_stdp.rs
+++ b/src/rm_stdp.rs
@@ -93,10 +93,15 @@ impl Default for EligibilityTrace {
 /// to change it on a live network.
 ///
 /// `w_min` / `w_max` take precedence over the engine's L1 weight budget: the
-/// renormalization pass in `step` scales toward the budget and then clamps, so
-/// narrowing this range leaves each neuron's weight sum off budget by however
-/// much the clamp binds. The defaults cannot bind (weights are non-negative and
-/// `w_max` equals the budget), so the budget holds exactly under them.
+/// renormalization pass in `step` scales toward the budget and then clamps, so a
+/// binding bound leaves the weight sum off budget in whichever direction it
+/// binds — a lowered `w_max` leaves it short, a raised `w_min` can lift it past.
+/// Under the defaults the clamp cannot bind (weights are non-negative and
+/// `w_max` equals the budget), so the budget holds exactly.
+///
+/// All of that applies only to a neuron the renormalization pass actually
+/// reaches — one whose weights already sum above its `1e-6` threshold. A blank
+/// neuron stays at zero: nothing scales a zero vector up to the budget.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RmStdpConfig {
     /// Eligibility trace decay time constant, in steps. Typical values are 50-100.


### PR DESCRIPTION
## **User description**
Closes #73
Closes #74
Refs #72

## The gap

`EligibilityTrace` and `RmStdpConfig` were public, listed in the README under reward-modulated STDP, and unused by the live engine. `SpikingNetwork::apply_stdp` recomputed a spike-timing kernel inline and wrote straight into `LifNeuron::weights`, so the eligibility half of R-STDP — accumulate a trace of recent coincidences, then let reward convert it — existed only as a decorative building block. Four separate docs had to repeat the caveat.

**Decision: wire, not demote.** Recorded in [`docs/adr/002-wire-eligibility-traces.md`](docs/adr/002-wire-eligibility-traces.md) with the rejected alternatives.

## The wiring

- `LifNeuron` gains `eligibility: Vec<EligibilityTrace>`, one per input channel, indexed exactly like `weights`. `SpikingNetwork` gains `stdp_config: RmStdpConfig`. Both are `#[serde(default)]`, and `apply_stdp` resizes a missing trace vector, so pre-0.6 checkpoints still deserialize and step.
- `apply_stdp` runs every step now. Traces decay and accumulate **regardless of dopamine**; dopamine gates only `w += reward_lr × dopamine_lr × trace`. That split is the whole point — reward can arrive several steps after the coincidence it pays for and still find the credit waiting.
- Accumulation is **event-gated**: a coincidence is recorded on the step it happens (post fired now → potentiation at `Δt ≥ 0`; pre fired now after an earlier post → depression at negative `Δt`), never re-applied from stale `last_spike_time` values. Re-applying the kernel every step would inflate one spike pair toward `tau × kernel` — learning that looks real but is an artifact of the loop, which is the "silent no-op that looks like learning" #73 rules out.
- Traces past the last input channel are decayed too. A caller can give a neuron more weights than the network has channels; those synapses have no input that could spike, and the per-channel loop stopped before reaching them, so a planted or deserialized trace stayed frozen there forever.
- New API: `EligibilityTrace::new` / `kernel` / `accumulate` / `reset`, `Default` for both types, `RM_STDP_TAU_ELIGIBILITY` / `RM_STDP_REWARD_LR`, and `SpikingNetwork::set_rm_stdp_config`. `reset()` now clears traces.

## Hardening the newly-public surface

Promoting the R-STDP parameters from constants to public config fields opened a family of failure modes that could not exist before. Review found them one at a time; **each was reproduced before being fixed**.

| Input | Failure if unguarded | Resolution |
|---|---|---|
| `reward_lr = NaN` | `NaN` weight, and the L1 pass then skips that neuron **forever** (`NaN > 1e-6` is false) | `effective_reward_lr()` |
| `tau_eligibility` non-finite or non-positive | `NaN` propagates into the banked value; `+∞` disables decay; `0.0` erases every trace at once; negative grows them without bound | `effective_tau_eligibility()`, plus the same guard in `decay()` |
| `w_min > w_max`, non-finite | `f32::clamp` **panics** inside a `Result`-returning `step` | `weight_bounds()` |
| `w_min < 0` | weights go inhibitory against a documented invariant, total goes negative, renormalization dies permanently | `weight_bounds()` rejects it |
| `EligibilityTrace::value = NaN` | same permanent poisoning, reachable without going through `accumulate` | `apply_stdp` clears it, so the synapse recovers |
| `kernel(NaN)` | `NaN` took the depression branch (`NaN >= 0.0` is false) and poisoned whichever trace it landed in | `kernel` returns `0.0` for a non-finite delta |
| `w_min > 0` on a partly-connected neuron | an **unrewarded** step conjured a connection at `w_min`, contradicting the gate | renormalization leaves exact zeros alone |
| `reward_lr = 0` with `w_min > 0` | conversion disabled, yet the clamp still lifted an unconnected synapse to the floor and the L1 pass scaled it up | `apply_stdp` writes only on a non-zero update |
| **depression** on a zero-weight synapse with `w_min > 0` | `(0.0 + dw).clamp(w_min, w_max)` returns `w_min` — weakening a synapse *connected* it | only potentiation may bring a synapse online |

The through-line: all-public fields with no constructor invariants mean the engine has to treat every `f32` reaching the learning path as untrusted at the point of use. `set_rm_stdp_config` normalizes what it stores; direct field assignment still works and is still safe, because reads go through the same guards.

Bound, not rate, is a deliberate line: a negative `reward_lr` inverts the direction of learning, which is unusual but coherent, so it passes through. A negative weight bound contradicts a stated invariant of the model, so it does not.

## Proof, not promise (#74)

Engine tests drive `step` across many steps and assert on real dynamics:

| Test | Claim |
|---|---|
| `traces_accumulate_without_dopamine_but_weights_hold` | gate shut → weights bit-identical, driven traces positive, silent traces zero |
| `dopamine_converts_traces_into_weight_change` | driven synapses potentiate, silent ones lose L1 share |
| `weight_change_scales_with_dopamine_level` | more dopamine buys more learning |
| `reward_pays_out_the_banked_trace_not_just_the_latest_spike` | a banked trace pays several times a fresh single coincidence under identical reward |
| `trace_converts_on_a_step_with_no_new_coincidence` | deferred credit assignment with zero spikes on the rewarded step |
| `post_before_pre_drives_depression_and_respects_w_min` | the LTD sign |
| `depression_clamps_a_connected_synapse_at_w_min` | the floor binds where an update actually applies |
| `rewarded_depression_does_not_connect_a_zero_weight_synapse` | …and does not, where it does not |
| `zero_reward_rate_leaves_an_unconnected_synapse_at_zero` | a disabled learning rate cannot change connectivity through the bounds |
| `one_spike_pair_is_counted_once_not_re_accumulated` | a quiet step decays, it does not re-count |
| `traces_past_the_last_channel_still_decay` | no trace is frozen out of the loop |
| `default_bounds_keep_the_l1_sum_on_budget` / `configured_bounds_take_precedence_over_the_l1_budget` | both halves of the documented precedence |
| `positive_w_min_does_not_seed_a_blank_network` / `…_untouched_zero_weights` | bounds gate updates, they do not fabricate synapses |
| `non_finite_reward_lr` / `…_tau_eligibility` / `…_trace_value_cannot_poison_weights` | garbage input degrades, never wedges |
| `negative_w_min_cannot_make_weights_inhibitory` | the excitatory invariant holds |
| `pre_0_6_state_without_new_fields_loads_and_steps` | strips both fields from serialized JSON, deserializes, steps, self-heals |

Weight seeds are chosen so the L1 renormalization pass is an exact no-op, and stimuli are `1.0`/`0.0`, so no assertion depends on an RNG outcome.

`examples/rstdp_demo.rs` prints values read back from the network rather than narrating them:

```
  after 10 steps  | ch0: w=0.5000 e=+0.0915 | ...   # dopamine 0.0: banked, unpaid
  after 10 steps  | ch0: w=0.5148 e=+0.1665 | ...   # dopamine 0.9: paid out
  Weight deltas:  | ch0: +0.0148 | ch1: +0.0148 | ch2: -0.0148 | ch3: -0.0148
```

Its `RmStdpConfig` scenario snapshots the network through serde, keeps the twin on the defaults, and runs both through the same ten rewarded steps — so the slower payout and the longer-held trace are **measured against a control**, not asserted, and the printed ratio is decomposed rather than attributed to one knob.

Benches cover trace accumulation, the trace → weight conversion, and rewarded vs unrewarded engine steps, and are listed in `benches/README.md`. The engine-step benches warm to steady state first: `apply_stdp` skips the decay `exp` while a trace is still exactly zero, so timing from a blank network would measure that transient instead of a running one. The conversion bench is batched rather than carrying its weight across iterations, which pinned it at `w_max` within a couple of hundred samples and timed a saturated synapse. `REVIEW.md` gains fail-fast regression guards so a future refactor cannot quietly revert to an inline rule and leave the types decorative again.

## Breaking behavior and migration

- **Behavioral.** Weight updates flow through a decaying trace instead of being recomputed from raw spike times, so same-input runs will not reproduce pre-0.6 trajectories.
- **Source.** Both structs have public fields and neither is `#[non_exhaustive]`, so the new fields break downstream struct literals. Fill from `..LifNeuron::new()` / `..Default::default()`, or use the constructors — README migration notes cover it with a compile-verified snippet.
- **Serialized state** written by 0.5.x stays deserializable in self-describing formats (JSON, YAML, RON, map-encoded MessagePack). `#[serde(default)]` cannot rescue positional binary formats like `bincode`/`postcard`; re-serialize before upgrading. Checkpoints written by 0.6 carry the new fields and will not load into 0.5.x.
- `apply_stdp` no longer early-returns when dopamine is near zero, so it touches every synapse each step. Traces still at exactly zero skip both the decay `exp` and the conversion, so a blank or unrewarded network stays cheap.

## Version

**Bumped to 0.6.0** (`75dc703`): `Cargo.toml`, `Cargo.lock`, the `CHANGELOG.md` section (`[Unreleased]` → `[0.6.0] - 2026-08-29`, shaped like the `[0.5.2]` entry down to its "publish after this tag lands" note), and the README install pin, migration-notes heading, and Docker example tags.

I originally deferred this to a separate release PR and was wrong to. [AGENTS.md](https://github.com/Limen-Neural/neuromod/blob/main/AGENTS.md) states under PR conventions that breaking public API changes bump the minor version for pre-1.0 and update the README migration notes — a rule for the PR making the break. The `main` practice I cited against it turns out to support both patterns (`ef9fba8` was a dedicated release PR; `5bdf94e` bumped inside a content PR), so the written rule wins.

One consequence stated plainly: **the install pin now leads crates.io until the tag lands** — the same window the `[0.5.2]` entry describes, and the README says so in a line rather than letting a reader hit a resolution failure. If you'd rather the pin trail the published version, that's a one-line revert.

## Epic #72 status

All three acceptance criteria are met — decision recorded (ADR 002), B2/B3 closed by this PR, and docs now describe the wired path with tests and a demo behind it. Leaving the epic itself for you to close.

## Validation

Full `REVIEW.md` gate, clean on every push: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-features`, `cargo test --all-features` (**102 unit + 7 doctests**), `cargo bench --no-run --all-features`, all four examples in debug and release, `cargo doc` domain-agnostic grep, the regression guards, and the `[[bench]] harness = false` check. MSRV pins stay identical across `Cargo.toml`, `rust-toolchain.toml`, and `ci.yml`. `serde_json` added as a dev-dependency for the checkpoint test — already in `Cargo.lock` via criterion, so no new transitive deps.

**Codacy** was the one non-green check, and its findings are now addressed at the source rather than waived:

| Finding | Status |
|---|---|
| `CLAUDE.md:100` — 43-word instruction (Comprehensibility) | fixed in `6829bc2`: split into a lead sentence plus one bullet per format class |
| `CLAUDE.md:100` — "RON" undefined on first use (Comprehensibility) | fixed in `6829bc2`: expanded to Rusty Object Notation |
| `examples/rstdp_demo.rs:179` — `scenario_slow_traces` at 58 NLOC, limit 50 (Complexity) | fixed in `0447902`: the result decomposition moved into `explain_slow_vs_default`; every function in the example is now under the limit, largest 37 |
| `examples/rstdp_demo.rs:10` — `main` at 212 NLOC (Complexity) | already stale — the earlier split in `07fda5a` left `main` at 15 |

An [earlier comment](https://github.com/Limen-Neural/neuromod/pull/103#issuecomment-5460880219) said this detail was reachable only from the Codacy dashboard. That was wrong: Codacy's public analysis API serves per-PR findings without credentials, and the four above came from it. The stale `main` row is why the issue count had moved without the code matching — the reported analysis was pinned to `0e810b9`, three commits behind.

The `0447902` extraction is behaviour-preserving: a full demo run diffs byte-identical against the previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hVoc6MTmfrfV1WvjhQ496


___

## **CodeAnt-AI Description**
Enable delayed reward credit assignment through live eligibility traces

### What Changed
- Network synapses now accumulate and decay spike-timing credit on each step, even without dopamine; dopamine converts the stored credit into weight changes when reward arrives later.
- Spike pairs are recorded only when a new pre- or post-synaptic spike occurs, preventing repeated learning from stale spike times.
- R-STDP settings now control trace lifetime, reward learning rate, and safe weight bounds; invalid settings fall back to usable defaults, and zero-weight synapses remain unconnected unless a valid potentiation updates them.
- Existing self-describing checkpoints can load without the new trace and configuration fields, while reset clears accumulated eligibility credit.
- Added coverage, benchmarks, documentation, and a demo showing real trace accumulation, delayed reward payout, and configurable learning behavior.

### Impact
`✅ Delayed rewards can reinforce earlier spike coincidences`
`✅ Fewer runaway or fabricated synaptic updates`
`✅ Safer checkpoint upgrades and R-STDP configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
