### PR TITLE
docs(benches): publish measured Criterion baseline table

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -94,10 +94,12 @@ Benchmarks neuromodulator impact on network performance:
 
 ## Measured Baseline
 
-This crate makes no unqualified "high-performance" claim; the numbers below are what
-the benches in this directory actually report. They are a single-machine snapshot, not
-a performance SLA or a cross-crate comparison — re-run the suite yourself with
-`cargo bench` before relying on any of this for a decision.
+This crate makes no unqualified "high-performance" claim. The timing tables below are
+what the benches in this directory actually report; the byte-size table in the "Memory"
+section further down is a separate `size_of::<T>()` measurement, not a bench result (see
+that section for how it was taken). All of it is a single-machine snapshot, not a
+performance SLA or a cross-crate comparison — re-run the suite yourself with `cargo bench`
+before relying on any of this for a decision.
 
 - **Commit:** `5a6ac98`
 - **Date:** 2026-09-06
@@ -165,8 +167,9 @@ loop structure implies.
 
 ### Memory (`memory_bench.rs`)
 
-`size_of::<T>()` byte counts (measured separately from the timing benchmarks below, which
-time a constructor + `size_of_val` call rather than reporting a byte size):
+`size_of::<T>()` byte counts for the `x86_64-unknown-linux-gnu` target (layout can vary by
+target; measured separately from the timing benchmarks below, which time a constructor +
+`size_of_val` call rather than reporting a byte size):
 
 | Type | Size |
 | --- | --- |

--- a/benches/README.md
+++ b/benches/README.md
@@ -72,9 +72,7 @@ Benchmarks synaptic plasticity operations:
 **Answers: "What's the memory overhead?"**
 
 Benchmarks memory usage and allocation:
-- `*_neuron_size` - Size of each neuron type struct
-- `spiking_network_size` - Size of the complete network
-- `neuromodulators_size` - Size of modulator struct
+- `*_neuron_size`, `spiking_network_size`, `neuromodulators_size` - time a construct-then-`size_of_val` call; at this scale the reported nanoseconds/picoseconds reflect construction and call overhead, not the struct's byte size. See [Measured Baseline](#measured-baseline) below for the actual `size_of::<T>()` byte counts, taken separately.
 - `network_allocation` - Network initialization time
 - `neuron_vector_allocation` - Vector allocation scaling (10, 50, 100, 500, 1000 neurons)
 - `weights_allocation` - Weight vector allocation scaling (16, 64, 256, 1024 weights)
@@ -94,44 +92,140 @@ Benchmarks neuromodulator impact on network performance:
 - `modulator_decay` - Modulator decay operation
 - `modulator_operations` - Individual modulator operations (add_reward, add_norepinephrine, boost_focus)
 
-## Interpreting Results
+## Measured Baseline
 
-### Neuron Step Performance
-- **LIF neurons** should be the fastest (simplest model)
-- **Izhikevich** adds complexity but remains fast
-- **Hodgkin-Huxley** is most computationally expensive (biophysically detailed)
-- **FitzHugh-Nagumo** offers a middle ground with 2D dynamics
+This crate makes no unqualified "high-performance" claim; the numbers below are what
+the benches in this directory actually report. They are a single-machine snapshot, not
+a performance SLA or a cross-crate comparison — re-run the suite yourself with
+`cargo bench` before relying on any of this for a decision.
 
-### STDP Performance
-- LTP/LTD operations should be sub-microsecond
-- Eligibility trace decay is a simple multiplication
-- Network STDP scales quadratically with neuron count (fully connected)
+- **Commit:** `5a6ac98`
+- **Date:** 2026-09-06
+- **Toolchain:** `rustc 1.97.1` (pinned in `rust-toolchain.toml`), `profile.bench` inherits
+  `profile.release` (`opt-level = 3`, `lto = true`, `codegen-units = 1`)
+- **Machine:** 4-core Intel Xeon @ 2.10GHz cloud CI container (not an isolated benchmarking
+  rig — expect run-to-run noise; several benchmarks below report outliers)
+- **Command:** `cargo bench --all-features --bench <name> -- --save-baseline gh77-2026-09-06`
+- Times are Criterion's reported median (midpoint of its confidence interval).
 
-### Memory Overhead
-- LIF neurons: ~48-64 bytes (depending on weights)
-- Izhikevich neurons: ~32 bytes (compact state)
-- Hodgkin-Huxley: ~120 bytes (multiple gating variables)
-- Network overhead dominated by weight matrices
+### Neuron step (`neuron_bench.rs`)
 
-### Modulation Impact
-- Baseline performance: reference point
-- Dopamine: enables learning (may add small overhead)
-- Norepinephrine: stress/arousal modulation (minimal overhead)
-- Acetylcholine: affects decay rates (minimal overhead)
-- Combined modulators: should show minimal cumulative overhead
+| Benchmark | Median time |
+| --- | --- |
+| `lif_check_fire` | 0.55 ns |
+| `lapicque_step` | 1.64 ns |
+| `lif_integrate` | 2.35 ns |
+| `lif_full_step` | 4.64 ns |
+| `izhikevich_step` | 10.05 ns |
+| `fitzhugh_nagumo_step` | 321 ns |
+| `hodgkin_huxley_step` | 627 ns |
 
-## Performance Targets
+On this run the ranking is LIF < Izhikevich < FitzHugh-Nagumo < Hodgkin-Huxley, consistent
+with their relative model complexity (2 state variables for LIF's check/integrate split,
+4 gating variables for Hodgkin-Huxley).
 
-For a production-ready SNN library:
-- **Neuron step**: < 100 ns for LIF, < 500 ns for Izhikevich
-- **STDP update**: < 50 ns per synapse
-- **Network step**: < 1 µs per neuron (including STDP)
-- **Memory**: < 1 KB per neuron (including weights)
-- **Modulation overhead**: < 5% of baseline step time
+### STDP / plasticity (`stdp_bench.rs`)
+
+| Benchmark | Median time |
+| --- | --- |
+| `classical_stdp_ltp` | 0.58 ns |
+| `classical_stdp_ltd` | 0.61 ns |
+| `eligibility_trace_accumulate_ltp` | 2.89 ns |
+| `eligibility_trace_accumulate_ltd` | 3.22 ns |
+| `stdp_delta_t_calculation` | 3.37 ns |
+| `eligibility_trace_decay` | 36.5 ns |
+| `stdp_weight_update` | 7.11 ns |
+| `hebbian_network_update` | 13.3 ns |
+| `rm_stdp_trace_to_weight` | 8.26 ns |
+
+Full `SpikingNetwork::step` with trace bookkeeping (64 LIF neurons, 64 channels, steady
+state after 200 warm-up steps):
+
+| Benchmark | Median time |
+| --- | --- |
+| `engine_step/unrewarded` (dopamine = 0.0) | 35.6 µs |
+| `engine_step/rewarded` (dopamine = 0.9) | 51.2 µs |
+
+`stdp_network_size` (`HebbianIzhikevichNetwork::update_weights` over every pre/post pair,
+fully connected):
+
+| Network size | Median time |
+| --- | --- |
+| 10 | 134 ns |
+| 50 | 3.14 µs |
+| 100 | 10.9 µs |
+| 200 | 42.3 µs |
+
+10 → 50 neurons (5x) costs ~23x; 50 → 100 (2x) costs ~3.5x; 100 → 200 (2x) costs ~3.9x —
+close enough to O(n²) to call the fully-connected update quadratic in neuron count, as the
+loop structure implies.
+
+### Memory (`memory_bench.rs`)
+
+`size_of::<T>()` byte counts (measured separately from the timing benchmarks below, which
+time a constructor + `size_of_val` call rather than reporting a byte size):
+
+| Type | Size |
+| --- | --- |
+| `NeuroModulators` | 16 bytes |
+| `FitzHughNagumoNeuron` | 20 bytes |
+| `IzhikevichNeuron` | 32 bytes |
+| `HodgkinHuxleyNeuron` | 48 bytes |
+| `LapicqueNeuron` | 56 bytes |
+| `LifNeuron` | 80 bytes |
+| `SpikingNetwork` (empty banks) | 144 bytes |
+
+`LifNeuron` and `SpikingNetwork` hold `Vec` fields (`weights`, `eligibility`, the neuron
+banks themselves); the sizes above are the fixed struct layout only (each `Vec` is a
+pointer/len/cap triple) and exclude heap-allocated contents, which scale with channel and
+neuron count.
+
+Allocation timing:
+
+| Benchmark | Median time | Throughput |
+| --- | --- | --- |
+| `network_allocation` (`SpikingNetwork::new()`, 16 LIF + 5 Izhikevich, 16 channels) | 1.01 µs | — |
+| `neuron_vector_allocation/10` | 22.1 ns | 452 Melem/s |
+| `neuron_vector_allocation/50` | 133 ns | 375 Melem/s |
+| `neuron_vector_allocation/100` | 234 ns | 428 Melem/s |
+| `neuron_vector_allocation/500` | 954 ns | 524 Melem/s |
+| `neuron_vector_allocation/1000` | 2.59 µs | 387 Melem/s |
+| `weights_allocation/16` | 10.6 ns | 1.51 Gelem/s |
+| `weights_allocation/64` | 11.3 ns | 5.66 Gelem/s |
+| `weights_allocation/256` | 17.0 ns | 15.1 Gelem/s |
+| `weights_allocation/1024` | 73.3 ns | 14.0 Gelem/s |
+
+### Modulation (`modulation_bench.rs`)
+
+Full `SpikingNetwork::step` (default `new()`: 16 LIF, 5 Izhikevich, 16 channels):
+
+| Benchmark | Median time |
+| --- | --- |
+| `network_step_baseline` (no modulators) | 1.24 µs |
+| `network_step_with_dopamine` (0.8) | 1.27 µs |
+| `network_step_with_norepinephrine` (0.5) | 1.28 µs |
+| `network_step_with_acetylcholine` (0.8) | 1.28 µs |
+| `network_step_with_all_modulators` | 1.37 µs |
+
+`modulator_comparison` (each variant builds its own fresh network) and `dopamine_scaling`
+land in the same 1.05–1.38 µs band without a clean monotonic trend, and several of the
+groups above report 7–22% outliers — on this machine, single-run modulator overhead is not
+cleanly separable from sample-to-sample noise. Treat "modulators add roughly low-double-digit-percent
+overhead over baseline, or less" as the honest read of this data, not a precise percentage,
+and do not treat 5%-or-any-other threshold as a target this baseline demonstrates.
+
+Modulator primitive operations (not full network steps):
+
+| Benchmark | Median time |
+| --- | --- |
+| `modulator_add_reward` | 1.83 ns |
+| `modulator_boost_focus` | 1.86 ns |
+| `modulator_add_norepinephrine` | 2.16 ns |
+| `modulator_decay` | 36.4 ns |
 
 ## Continuous Benchmarking
 
-To track performance over time:
+To track performance over time on your own machine:
 ```bash
 # Save baseline
 cargo bench -- --save-baseline main
@@ -140,4 +234,8 @@ cargo bench -- --save-baseline main
 cargo bench -- --baseline main
 ```
 
-Criterion will generate comparison reports showing performance regressions or improvements.
+Criterion will generate comparison reports showing performance regressions or
+improvements. Criterion's `--save-baseline` output lives under the git-ignored
+`target/criterion/`, so it never lands in this repo — the *Measured Baseline* table
+above is the durable, reviewable record; regenerate it (and update the commit/date
+above) whenever a change to `src/` is expected to move these numbers materially.

--- a/benches/README.md
+++ b/benches/README.md
@@ -106,11 +106,13 @@ a performance SLA or a cross-crate comparison — re-run the suite yourself with
 - **Machine:** 4-core Intel Xeon @ 2.10GHz cloud CI container (not an isolated benchmarking
   rig — expect run-to-run noise; several benchmarks below report outliers)
 - **Command:** `cargo bench --all-features --bench <name> -- --save-baseline gh77-2026-09-06`
-- Times are Criterion's reported median (midpoint of its confidence interval).
+- Times are Criterion's reported point estimate — the middle value of its
+  `[lower estimate upper]` confidence-interval output. This is not a statistical median,
+  and the interval is not guaranteed to be symmetric around it.
 
 ### Neuron step (`neuron_bench.rs`)
 
-| Benchmark | Median time |
+| Benchmark | Point estimate |
 | --- | --- |
 | `lif_check_fire` | 0.55 ns |
 | `lapicque_step` | 1.64 ns |
@@ -121,12 +123,13 @@ a performance SLA or a cross-crate comparison — re-run the suite yourself with
 | `hodgkin_huxley_step` | 627 ns |
 
 On this run the ranking is LIF < Izhikevich < FitzHugh-Nagumo < Hodgkin-Huxley, consistent
-with their relative model complexity (2 state variables for LIF's check/integrate split,
-4 gating variables for Hodgkin-Huxley).
+with their relative model complexity: LIF integrates a single membrane-potential state,
+Izhikevich and FitzHugh-Nagumo each track two coupled state variables, and Hodgkin-Huxley
+tracks four (membrane potential plus three gating variables `m`, `h`, `n`).
 
 ### STDP / plasticity (`stdp_bench.rs`)
 
-| Benchmark | Median time |
+| Benchmark | Point estimate |
 | --- | --- |
 | `classical_stdp_ltp` | 0.58 ns |
 | `classical_stdp_ltd` | 0.61 ns |
@@ -141,7 +144,7 @@ with their relative model complexity (2 state variables for LIF's check/integrat
 Full `SpikingNetwork::step` with trace bookkeeping (64 LIF neurons, 64 channels, steady
 state after 200 warm-up steps):
 
-| Benchmark | Median time |
+| Benchmark | Point estimate |
 | --- | --- |
 | `engine_step/unrewarded` (dopamine = 0.0) | 35.6 µs |
 | `engine_step/rewarded` (dopamine = 0.9) | 51.2 µs |
@@ -149,7 +152,7 @@ state after 200 warm-up steps):
 `stdp_network_size` (`HebbianIzhikevichNetwork::update_weights` over every pre/post pair,
 fully connected):
 
-| Network size | Median time |
+| Network size | Point estimate |
 | --- | --- |
 | 10 | 134 ns |
 | 50 | 3.14 µs |
@@ -182,7 +185,7 @@ neuron count.
 
 Allocation timing:
 
-| Benchmark | Median time | Throughput |
+| Benchmark | Point estimate | Throughput |
 | --- | --- | --- |
 | `network_allocation` (`SpikingNetwork::new()`, 16 LIF + 5 Izhikevich, 16 channels) | 1.01 µs | — |
 | `neuron_vector_allocation/10` | 22.1 ns | 452 Melem/s |
@@ -199,7 +202,7 @@ Allocation timing:
 
 Full `SpikingNetwork::step` (default `new()`: 16 LIF, 5 Izhikevich, 16 channels):
 
-| Benchmark | Median time |
+| Benchmark | Point estimate |
 | --- | --- |
 | `network_step_baseline` (no modulators) | 1.24 µs |
 | `network_step_with_dopamine` (0.8) | 1.27 µs |
@@ -216,7 +219,7 @@ and do not treat 5%-or-any-other threshold as a target this baseline demonstrate
 
 Modulator primitive operations (not full network steps):
 
-| Benchmark | Median time |
+| Benchmark | Point estimate |
 | --- | --- |
 | `modulator_add_reward` | 1.83 ns |
 | `modulator_boost_focus` | 1.86 ns |


### PR DESCRIPTION
## **User description**
## Summary

Closes https://github.com/Limen-Neural/neuromod/issues/77.

- Ran the full Criterion bench suite (`neuron_bench`, `stdp_bench`, `memory_bench`, `modulation_bench`) via `cargo bench --all-features --bench <name> -- --save-baseline gh77-2026-09-06` and recorded the real numbers in `benches/README.md` under a new **Measured Baseline** section, with machine/toolchain/commit provenance.
- Replaced the previous unsubstantiated "should be fastest" / "sub-microsecond" / `< 100 ns` target-style claims with what was actually measured — including calling out that the measured modulator overhead (~10%, noisy) does **not** support the old "< 5%" claim, rather than repeating it.
- Corrected the `*_neuron_size` / `spiking_network_size` / `neuromodulators_size` bench descriptions: those benchmarks time a constructor + `size_of_val` call (picosecond-scale), not the struct's actual byte size. Added real `size_of::<T>()` byte counts (measured separately) for each neuron type, `NeuroModulators`, and `SpikingNetwork`.
- No source changes — `benches/*.rs` and `src/` are untouched; benches still compile and run exactly as before via `cargo bench`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (111 unit tests + 10 doctests pass)
- [x] `cargo bench --no-run --all-features` (compiles)
- [x] Full `cargo bench` run against all four bench targets to produce the numbers in the table
- [x] `cargo doc --all-features --no-deps` + domain-hygiene grep (no forbidden terms)
- [x] Examples smoke: `basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo` all run without panics
- [x] `git diff --stat origin/main...HEAD` — only `benches/README.md` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M41xyemEfoWsSyzAr9JxKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01M41xyemEfoWsSyzAr9JxKf)_


___

## **CodeAnt-AI Description**
Publish measured benchmark results and clarify memory measurements

### What Changed
- Replaces unverified performance claims and targets with measured Criterion results for neuron steps, plasticity, memory allocation, and modulation.
- Adds benchmark provenance, machine limitations, and guidance to treat the results as a single-machine snapshot rather than a guarantee.
- Corrects memory benchmark descriptions and lists the actual byte sizes of neuron, network, and modulator structures separately from construction timing.
- Documents fully connected plasticity scaling and clarifies that observed modulator overhead is noisy and does not establish a fixed percentage target.
- Explains how to regenerate and maintain the reviewable baseline while keeping generated Criterion output out of the repository.

### Impact
`✅ Trustworthy performance reference`
`✅ Accurate structure size information`
`✅ Clearer benchmark limitations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
