### PR TITLE
chore(rust): upgrade MSRV pin to 1.98.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.1-slim-bookworm
+FROM rust:1.98.0-slim-bookworm
 
 # Add components used by CI, local review, and the dev container post-create step.
 RUN rustup component add rustfmt clippy llvm-tools-preview

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -4,9 +4,9 @@
 
 initialize: |
   # Pin and activate the Rust toolchain used by rust-toolchain.toml and CI.
-  rustup toolchain install 1.97.1
-  rustup default 1.97.1
-  rustup component add --toolchain 1.97.1 rustfmt clippy llvm-tools-preview
+  rustup toolchain install 1.98.1
+  rustup default 1.98.1
+  rustup component add --toolchain 1.98.1 rustfmt clippy llvm-tools-preview
 
   # Optional but commonly used review/CI tools referenced by REVIEW.md.
   cargo install cargo-nextest --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Install Rust 1.97.1
+      - name: Install Rust 1.98.1
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # pinned action
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           components: clippy, rustfmt
 
       # Keep Cargo.toml rust-version, rust-toolchain.toml, and this job's

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust 1.97.1
+      - name: Install Rust 1.98.1
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # pinned action
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           components: clippy, rustfmt, llvm-tools-preview
 
       - name: Rust Cache

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust 1.97.1
+      - name: Install Rust 1.98.1
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # pinned action
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           components: clippy, rustfmt
 
       - uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Part of the [Limen-Neural](https://github.com/Limen-Neural) ecosystem. See [docs
 | `examples/` | Runnable demos (`basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo`) |
 | `benches/` | Criterion benchmarks |
 | `docs/` | Architecture docs: boundary matrix, org modularization index, signal unit conventions, Architecture Decision Records (ADRs) |
-| [rust-toolchain.toml](rust-toolchain.toml) | Pinned Rust toolchain (1.97.1) |
+| [rust-toolchain.toml](rust-toolchain.toml) | Pinned Rust toolchain (1.98.1) |
 | `.devcontainer/` | VS Code dev container configuration |
 | `AGENTS.md` | Agent instructions (this file) |
 | `.github/workflows/` | CI/CD pipelines |
@@ -36,7 +36,7 @@ Part of the [Limen-Neural](https://github.com/Limen-Neural) ecosystem. See [docs
 ## Toolchain
 
 - **Edition:** 2024
-- **Pinned toolchain:** `1.97.1` (see [rust-toolchain.toml](rust-toolchain.toml))
+- **Pinned toolchain:** `1.98.1` (see [rust-toolchain.toml](rust-toolchain.toml))
 
 ## Build, test, and examples
 
@@ -78,7 +78,7 @@ Open in VS Code with the Dev Containers extension or run:
 devcontainer up --workspace-folder .
 ```
 
-The container is `rust:1.97.1-slim-bookworm`. `cargo fetch` runs on first create. The `vscode` user owns the toolchain, so `cargo` commands and component installs work from the terminal. `cargo-llvm-cov` is also supported.
+The container is `rust:1.98.0-slim-bookworm`. `cargo fetch` runs on first create. The `vscode` user owns the toolchain, so `cargo` commands and component installs work from the terminal. `cargo-llvm-cov` is also supported.
 
 ## Boundaries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ cargo run --example rstdp_demo
 
 Before pushing changes that touch `src/`, `benches/`, `examples/`, `tests/`, or `Cargo.toml`, run the full gate in [REVIEW.md](REVIEW.md). That gate covers fmt, clippy, build, test, examples smoke, docs domain-hygiene grep, and public-API regression greps.
 
-The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.97.1). A matching `.devcontainer/` is available (`devcontainer up --workspace-folder .`).
+The toolchain is pinned in [rust-toolchain.toml](rust-toolchain.toml) (1.98.1). A matching `.devcontainer/` is available (`devcontainer up --workspace-folder .`).
 
 ## Architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "neuromod"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.97.1"
+rust-version = "1.98.1"
 license = "MIT OR Apache-2.0"
 authors = ["Raul Montoya Cardenas <montoyaraul34@gmail.com>"]
 description = "Biologically inspired SNN primitives in Rust: LIF/Izhikevich SpikingNetwork, neuromodulators, STDP building blocks, and standalone neuron models."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-stage Docker for neuromod (library + examples/tests)
-# Builder — Rust 1.98.0 (bookworm) keeps glibc in sync with the debian:bookworm-slim runtime.
-# Toolchain pin (Cargo.toml/rust-toolchain.toml/CI) is 1.98.1; this stays at 1.98.0 until
-# the upstream `rust:1.98.1-slim-bookworm` image is published.
+# Builder — bookworm base image keeps glibc in sync with the debian:bookworm-slim runtime.
+# The base image itself is rust:1.98.0-slim-bookworm (latest published tag; 1.98.1 has none
+# yet), but `COPY . .` brings in rust-toolchain.toml, so rustup fetches and uses the pinned
+# 1.98.1 toolchain for the actual `cargo build` below — the base image only supplies rustup
+# and the OS layer, not the toolchain version that compiles the crate.
 FROM rust:1.98.0-slim-bookworm AS builder
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Multi-stage Docker for neuromod (library + examples/tests)
-# Builder — Rust 1.97.1 (bookworm) keeps glibc in sync with the debian:bookworm-slim runtime.
+# Builder — Rust 1.98.0 (bookworm) keeps glibc in sync with the debian:bookworm-slim runtime.
+# Toolchain pin (Cargo.toml/rust-toolchain.toml/CI) is 1.98.1; this stays at 1.98.0 until
+# the upstream `rust:1.98.1-slim-bookworm` image is published.
 FROM rust:1.98.0-slim-bookworm AS builder
 WORKDIR /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Use them directly; use `HebbianIzhikevichNetwork` for a small classical-STDP Izh
 
 | | |
 |--|--|
-| **MSRV** | **Rust 1.97.1** (`rust-version` in `Cargo.toml`) |
+| **MSRV** | **Rust 1.98.1** (`rust-version` in `Cargo.toml`) |
 | **Edition** | 2024 |
-| **Pin** | [`rust-toolchain.toml`](rust-toolchain.toml) (channel `1.97.1`) |
+| **Pin** | [`rust-toolchain.toml`](rust-toolchain.toml) (channel `1.98.1`) |
 | **CI platforms** | **Linux**, **macOS**, and **Windows** (GitHub Actions matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`) |
 
 CI installs the same toolchain on each OS. Keep `Cargo.toml` `rust-version`, `rust-toolchain.toml`, and the version string in `.github/workflows/ci.yml` identical (the CI job fails if they drift).

--- a/azure-templates/buildtest.yml
+++ b/azure-templates/buildtest.yml
@@ -19,7 +19,7 @@ steps:
       path: target
 
   - script: |
-      rustup default 1.97.1
+      rustup default 1.98.1
       rustup component add rustfmt clippy llvm-tools-preview
     displayName: 'Set Rust toolchain'
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 components = ["rustfmt", "clippy", "llvm-tools-preview"]
 profile = "default"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Requirements
 //!
-//! - **Rust 1.97.1+** (MSRV; also `rust-version` in `Cargo.toml` and
+//! - **Rust 1.98.1+** (MSRV; also `rust-version` in `Cargo.toml` and
 //!   [`rust-toolchain.toml`](https://github.com/Limen-Neural/neuromod/blob/main/rust-toolchain.toml)).
 //! - Edition **2024**.
 //! - **CI-tested platforms:** Linux, macOS, and Windows (GitHub Actions matrix).


### PR DESCRIPTION
## Summary

- Bump the pinned Rust toolchain from `1.97.1` to `1.98.1` (latest stable, confirmed via `rustup check`) across every pin location: `Cargo.toml` `rust-version`, `rust-toolchain.toml` `channel`, and the `toolchain:` string in `.github/workflows/ci.yml`, `coverage.yml`, and `reviewdog.yml` (the MSRV single-source-of-truth CI check in `ci.yml` verifies these three stay identical).
- Also bump the Devin blueprint (`.devin/blueprint.yaml`) and Azure Pipelines template (`azure-templates/buildtest.yml`), which pin the same toolchain via `rustup`.
- Docker images: `rust:1.98.1-slim-bookworm` isn't published on Docker Hub yet (only `1.98.0-slim-bookworm` and earlier), so `Dockerfile` and `.devcontainer/Dockerfile` stay on `rust:1.98.0-slim-bookworm` — the latest available image — with a comment noting the toolchain pin is ahead of it. `rustup` inside those containers will still resolve to `1.98.1` automatically via `rust-toolchain.toml`.
- Updated documentation that names the MSRV (`README.md`, `CLAUDE.md`, `AGENTS.md`, `src/lib.rs` crate docs) to match. `CHANGELOG.md`'s historical `1.97.1` mention is left as-is (it's a record of a past release).

No functional/API changes — this is a toolchain version bump only.

## Test plan

- [x] Installed `rustc`/`cargo` 1.98.1 locally via `rustup`; `rust-toolchain.toml` correctly resolves the active toolchain to 1.98.1
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (111 unit tests + 10 doctests pass)
- [x] Examples smoke: `basic`, `basic_lif`, `hebbian_learning`, `rstdp_demo` all run without panics
- [x] `cargo bench --no-run --all-features` (all four bench targets compile)
- [x] `cargo doc --all-features --no-deps` + domain-hygiene grep (no forbidden terms)
- [x] REVIEW.md regression guards: public-API surface greps, R-STDP engine-wiring guard, bench-harness (`harness = false`) guard, and the MSRV single-source-of-truth check (`Cargo.toml` / `rust-toolchain.toml` / `ci.yml` all read back `1.98.1`)
- [ ] Docker builder/verify smoke — no Docker daemon available in this sandbox; CI's `docker build`/`docker verify`/`docker publish` jobs will exercise this on the actual toolchain/image combination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M41xyemEfoWsSyzAr9JxKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01M41xyemEfoWsSyzAr9JxKf)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the pinned Rust toolchain from 1.97.1 to 1.98.1 across `Cargo.toml`, `rust-toolchain.toml`, all CI workflows, the Devin blueprint, and the Azure template, and updates the docs that name the MSRV. No functional or API changes.

- Docker and devcontainer images stay on `rust:1.98.0-slim-bookworm` since no `1.98.1` image is published yet; the base image only supplies rustup and the OS layer, and rustup resolves `1.98.1` via `rust-toolchain.toml` for the actual build.

<sup>Written for commit 9b325b8675a3caff2290498e19f04ae03df30718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/neuromod/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

